### PR TITLE
Add Bitwarden API Step 0 spike CLI (#53)

### DIFF
--- a/app/spike/bwapi/Makefile
+++ b/app/spike/bwapi/Makefile
@@ -7,7 +7,7 @@ build:
 	./run.sh build -o /tmp/bwapi .
 
 run:
-	./run.sh run .
+	./run.sh
 
 tidy:
 	./run.sh mod tidy

--- a/app/spike/bwapi/Makefile
+++ b/app/spike/bwapi/Makefile
@@ -1,0 +1,13 @@
+# Spike helper: goenv may reject go.mod's "go 1.26" before GOTOOLCHAIN runs.
+# Prefer: ./run.sh  or  make build / make run
+
+.PHONY: build run tidy
+
+build:
+	./run.sh build -o /tmp/bwapi .
+
+run:
+	./run.sh run .
+
+tidy:
+	./run.sh mod tidy

--- a/app/spike/bwapi/README.md
+++ b/app/spike/bwapi/README.md
@@ -66,13 +66,14 @@ export BWSF_SPIKE_EMAIL='you@example.com'
 export BWSF_SPIKE_PASSWORD='…'
 # 任意: export BWSF_SPIKE_SERVER_URL='https://your-server'
 # 任意: export BWSF_SPIKE_TOTP='123456'
-./run.sh run .
-# または: make run
+./run.sh
+# または: make run / ./run.sh run .
 
 # Scenario B（ライブ）
 export BWSF_SPIKE_CLIENT_ID='user.…'
 export BWSF_SPIKE_CLIENT_SECRET='…'
-./run.sh run . apikey
+./run.sh apikey
+# または: ./run.sh run . apikey
 ```
 
 手動で同じことをする場合（このマシンで確認済み）:
@@ -110,7 +111,7 @@ stdout に次が揃うこと:
 
 ### Scenario B
 
-- Identity `POST …/connect/token`（`grant_type=client_credentials`, `scope=api`）で **`access_token` 取得**
+- Identity `POST …/connect/token`（`grant_type=client_credentials`, `scope=api` + device メタ）で **`access_token` 取得**
 - vault CRUD は不要
 - SDK に API Key ログインが無いため、スパイクは raw HTTP でプローブする
 
@@ -144,22 +145,25 @@ stdout に次が揃うこと:
 
 よくある原因（このスパイクで確認済み）:
 
-1. **`deviceName` 未送信** — Vaultwarden は `/identity/connect/token` で `device_name cannot be blank` を返す。  
-   公式 cloud より厳しい。スパイクは常に `DeviceName` / `DeviceType` / `DeviceIdentifier` を付ける。
+1. **デバイスメタ未送信** — Vaultwarden は `/identity/connect/token` で空白を拒否する。  
+   - Scenario A（password）: `device_name cannot be blank`  
+   - Scenario B（`client_credentials`）: `device_identifier cannot be blank`（続けて name / type も必須）  
+   公式 cloud より厳しい。スパイクは常に `deviceIdentifier` / `deviceName` / `deviceType` を付ける（A は SDK `LoginOptions`、B は raw form）。
 2. **SDK がボディを捨てる** — VW の 400 JSON は `"error":""`（空文字）になりがちで、SDK は OAuth の `error` が空だと `KindUnknown` + `status=400` だけにする。本物の理由は `message` / `errorModel.message` 側。
 3. **認証失敗も同じ opaque 400** — パスワード不正時も VW は同様の形のため、SDK 上は `unknown status=400` に見えることがある。
 
 失敗時のスパイク出力:
 
 - 導出済み `identity` / `api` URL
-- SDK `Error` の kind / status / code / message
-- パスワードを使わない diagnose POST（`deviceName` あり／なし）でレスポンスボディ例を表示
+- SDK `Error` の kind / status / code / message（Scenario A）
+- パスワードを使わない diagnose POST（`deviceName` あり／なし）でレスポンスボディ例を表示（Scenario A）
+- Scenario B は raw HTTP のため、失敗時にレスポンスボディをそのまま表示
 
 ### VW API 不一致 vs 設定ミス
 
 | 症状 | 解釈 |
 |------|------|
-| prelogin 200、token で `device_name cannot be blank` | **設定／クライアント側**（デバイスメタ不足）。修正可能 |
+| prelogin 200、token で `device_name` / `device_identifier cannot be blank` | **設定／クライアント側**（デバイスメタ不足）。修正可能 |
 | prelogin / identity が 404 | ベース URL 誤り、またはリバースプロキシで `/identity` が届いていない |
 | token が常に opaque 400 で diagnose も意味不明 | **VW と SDK の API 差**の可能性。Issue に diagnose 全文を貼る |
 
@@ -179,7 +183,7 @@ stdout に次が揃うこと:
 
 - **Personal API Key:** `bitwarden-go-sdk` v0.4.0 に client_credentials / API Key ログイン API なし → Scenario B は raw HTTP。
 - **Vaultwarden:** README で non-goal。加えて **HTTPS 必須**（ローカル HTTP VW はそのままでは `NewClient(WithServerURL)` 不可）。
-- **deviceName 必須 (VW):** SDK は `LoginOptions.DeviceName` が空だと form に載せない。VW は 400 `device_name cannot be blank`。スパイクは固定デバイスメタを送る。
+- **device メタ必須 (VW):** password / client_credentials とも `deviceIdentifier`・`deviceName`・`deviceType` が必要。SDK は `LoginOptions` が空だと form に載せない。スパイクは固定デバイスメタを送る。
 - **opaque 400:** VW の token エラー JSON は `"error":""` が多く、SDK がボディを捨てて `unknown status=400` になる。失敗時は diagnose 出力を参照。
 - **2FA:** `CompleteLogin` + `TwoFactorProviderAuthenticator`。他プロバイダは要コード変更。
 - alpha API は破壊的変更があり得る。

--- a/app/spike/bwapi/README.md
+++ b/app/spike/bwapi/README.md
@@ -1,0 +1,185 @@
+# bwapi — Issue #53 Step 0 spike
+
+本番の `bwsf` CLI とは **別モジュール・別バイナリ** の使い捨て実験です。  
+`app/go.mod` や `app/src/` には SDK を入れず、コミュニティ Go SDK  
+[`github.com/bnema/bitwarden-go-sdk`](https://github.com/bnema/bitwarden-go-sdk)（v0.4.x）で vault 操作が通るかだけを検証します。
+
+> **注意:** SDK は alpha。公式サポートは Bitwarden cloud / 公式 self-hosted のみで、**Vaultwarden は非目標**と明記されています。HTTPS 必須（`http://` は SDK が拒否）。
+
+---
+
+## 必要な環境変数
+
+### Scenario A（メイン go/no-go）
+
+| 変数 | 必須 | 説明 |
+|------|------|------|
+| `BWSF_SPIKE_EMAIL` | ○ | ログイン用メール |
+| `BWSF_SPIKE_PASSWORD` | ○ | マスターパスワード |
+| `BWSF_SPIKE_SERVER_URL` | − | セルフホスト / Vaultwarden のベース URL（例: `https://vw.example.com`、末尾 `/` 可）。未設定時は Bitwarden US cloud。SDK は `{url}/identity` と `{url}/api` に導出 |
+| `BWSF_SPIKE_TOTP` | − | 2FA が必要な場合の authenticator コード。未設定なら対話プロンプト |
+
+### Scenario B（Personal API Key プローブ）
+
+| 変数 | 必須 | 説明 |
+|------|------|------|
+| `BWSF_SPIKE_CLIENT_ID` | ○ | Personal API Key の `client_id`（例: `user.…`） |
+| `BWSF_SPIKE_CLIENT_SECRET` | ○ | Personal API Key の `client_secret` |
+| `BWSF_SPIKE_SERVER_URL` | − | 設定時は Identity を `<url>/identity` と導出 |
+| `BWSF_SPIKE_IDENTITY_URL` | − | Identity ベース URL の上書き（未設定時: cloud は `https://identity.bitwarden.com`） |
+
+シークレットをコードや git に書かないこと。
+
+---
+
+## ビルド・実行
+
+SDK は **Go 1.26+** を要求します（`go.mod` の `go 1.26`）。
+
+### goenv 注意（このマシン）
+
+goenv は `go.mod` の `go 1.26` を見て **GOTOOLCHAIN より先に** バージョン解決します。  
+`goenv versions` に 1.26 が無いと、次で失敗します:
+
+```text
+goenv: version '1.26' is not installed
+```
+
+インストール済みは例: `1.25.7`（global）。対処は次のどちらか。
+
+#### 推奨: `./run.sh`（GOENV_VERSION + GOTOOLCHAIN=auto）
+
+`run.sh` がインストール済みの 1.25.x を検出し、`GOENV_VERSION` と `GOTOOLCHAIN=auto` を付けて `go` を呼びます（toolchain が 1.26 を取得）。
+
+```bash
+cd app/spike/bwapi
+
+# 依存整理
+./run.sh mod tidy
+
+# コンパイル確認（認証情報なしで OK）
+./run.sh build -o /tmp/bwapi .
+# または: make build
+
+# Scenario A（ライブ）
+export BWSF_SPIKE_EMAIL='you@example.com'
+export BWSF_SPIKE_PASSWORD='…'
+# 任意: export BWSF_SPIKE_SERVER_URL='https://your-server'
+# 任意: export BWSF_SPIKE_TOTP='123456'
+./run.sh run .
+# または: make run
+
+# Scenario B（ライブ）
+export BWSF_SPIKE_CLIENT_ID='user.…'
+export BWSF_SPIKE_CLIENT_SECRET='…'
+./run.sh run . apikey
+```
+
+手動で同じことをする場合（このマシンで確認済み）:
+
+```bash
+cd app/spike/bwapi
+GOENV_VERSION=1.25.7 GOTOOLCHAIN=auto go build -o /tmp/bwapi .
+GOENV_VERSION=1.25.7 GOTOOLCHAIN=auto go run .
+```
+
+#### 代替: goenv に 1.26 を入れる
+
+```bash
+goenv install 1.26
+cd app/spike/bwapi
+go run .   # または GOTOOLCHAIN=auto go run .
+```
+
+本番 `make build` / Dockerfile / brew には **含まれません**。
+
+---
+
+## 成功条件
+
+### Scenario A（go/no-go）
+
+stdout に次が揃うこと:
+
+1. `NewClient` 成功（cloud または `WithServerURL`）
+2. `BeginLogin`（必要なら `CompleteLogin`）成功
+3. `Sync` 成功
+4. フォルダ `bwsf-spike` が既存 or 新規作成
+5. Secure Note `bwsf-spike-note` の create → get/search → notes update 成功
+6. 最後に `SUCCESS (Scenario A): …`
+
+### Scenario B
+
+- Identity `POST …/connect/token`（`grant_type=client_credentials`, `scope=api`）で **`access_token` 取得**
+- vault CRUD は不要
+- SDK に API Key ログインが無いため、スパイクは raw HTTP でプローブする
+
+### Scenario C（PO Vaultwarden スモーク）
+
+1. Vaultwarden を **HTTPS** で用意（SDK は `http://` を拒否）
+2. `export BWSF_SPIKE_SERVER_URL='https://<your-vaultwarden>'`
+3. A と同じく email / password を設定し `go run .` を実行
+4. 結果（成功 / 失敗メッセージ全文）を Issue #53 に報告
+
+公式には VW 非対応のため、失敗してもスパイクの価値あり（制約の実証）。
+
+---
+
+## Vaultwarden troubleshooting
+
+### 期待する URL 形
+
+`BWSF_SPIKE_SERVER_URL=https://vw.example.com`（末尾スラッシュはスパイク／SDK が除去）のとき:
+
+| 用途 | URL |
+|------|-----|
+| Identity | `https://vw.example.com/identity` |
+| API | `https://vw.example.com/api` |
+| Prelogin | `POST …/identity/accounts/prelogin/password` |
+| Token | `POST …/identity/connect/token` |
+
+末尾 `/` だけでは 400 にはなりません。SDK の `NewSelfHosted` が path の trailing slash を strip します。
+
+### `BeginLogin: bitwarden: unknown status=400`
+
+よくある原因（このスパイクで確認済み）:
+
+1. **`deviceName` 未送信** — Vaultwarden は `/identity/connect/token` で `device_name cannot be blank` を返す。  
+   公式 cloud より厳しい。スパイクは常に `DeviceName` / `DeviceType` / `DeviceIdentifier` を付ける。
+2. **SDK がボディを捨てる** — VW の 400 JSON は `"error":""`（空文字）になりがちで、SDK は OAuth の `error` が空だと `KindUnknown` + `status=400` だけにする。本物の理由は `message` / `errorModel.message` 側。
+3. **認証失敗も同じ opaque 400** — パスワード不正時も VW は同様の形のため、SDK 上は `unknown status=400` に見えることがある。
+
+失敗時のスパイク出力:
+
+- 導出済み `identity` / `api` URL
+- SDK `Error` の kind / status / code / message
+- パスワードを使わない diagnose POST（`deviceName` あり／なし）でレスポンスボディ例を表示
+
+### VW API 不一致 vs 設定ミス
+
+| 症状 | 解釈 |
+|------|------|
+| prelogin 200、token で `device_name cannot be blank` | **設定／クライアント側**（デバイスメタ不足）。修正可能 |
+| prelogin / identity が 404 | ベース URL 誤り、またはリバースプロキシで `/identity` が届いていない |
+| token が常に opaque 400 で diagnose も意味不明 | **VW と SDK の API 差**の可能性。Issue に diagnose 全文を貼る |
+
+---
+
+## Identity URL の導出（Scenario B）
+
+| 条件 | Identity base | token endpoint |
+|------|---------------|----------------|
+| `BWSF_SPIKE_IDENTITY_URL` あり | その値 | `{base}/connect/token` |
+| `BWSF_SPIKE_SERVER_URL` あり | `{server}/identity` | `{server}/identity/connect/token` |
+| どちらも無し（cloud US） | `https://identity.bitwarden.com` | `…/connect/token` |
+
+---
+
+## 既知の SDK / 運用ギャップ（実装時メモ）
+
+- **Personal API Key:** `bitwarden-go-sdk` v0.4.0 に client_credentials / API Key ログイン API なし → Scenario B は raw HTTP。
+- **Vaultwarden:** README で non-goal。加えて **HTTPS 必須**（ローカル HTTP VW はそのままでは `NewClient(WithServerURL)` 不可）。
+- **deviceName 必須 (VW):** SDK は `LoginOptions.DeviceName` が空だと form に載せない。VW は 400 `device_name cannot be blank`。スパイクは固定デバイスメタを送る。
+- **opaque 400:** VW の token エラー JSON は `"error":""` が多く、SDK がボディを捨てて `unknown status=400` になる。失敗時は diagnose 出力を参照。
+- **2FA:** `CompleteLogin` + `TwoFactorProviderAuthenticator`。他プロバイダは要コード変更。
+- alpha API は破壊的変更があり得る。

--- a/app/spike/bwapi/go.mod
+++ b/app/spike/bwapi/go.mod
@@ -1,0 +1,10 @@
+module github.com/b4m-oss/bwsf/app/spike/bwapi
+
+go 1.26
+
+require github.com/bnema/bitwarden-go-sdk v0.4.0
+
+require (
+	golang.org/x/crypto v0.50.0 // indirect
+	golang.org/x/sys v0.43.0 // indirect
+)

--- a/app/spike/bwapi/go.sum
+++ b/app/spike/bwapi/go.sum
@@ -1,0 +1,16 @@
+github.com/bnema/bitwarden-go-sdk v0.4.0 h1:O7zAWX/++bZl5WDwZ5Fa8OKnBtkuJe9xDK1+7dN6CQo=
+github.com/bnema/bitwarden-go-sdk v0.4.0/go.mod h1:z9ZZyeUnDC1CZ/TwboEJ7fsaEmLwnqWIozdbkG5+JCY=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
+golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/app/spike/bwapi/main.go
+++ b/app/spike/bwapi/main.go
@@ -1,0 +1,455 @@
+// Command bwapi is a disposable spike CLI for Issue #53 Step 0.
+// It is NOT part of the production bwsf binary.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bnema/bitwarden-go-sdk/bitwarden"
+)
+
+const (
+	spikeFolderName = "bwsf-spike"
+	spikeNoteName   = "bwsf-spike-note"
+
+	envEmail        = "BWSF_SPIKE_EMAIL"
+	envPassword     = "BWSF_SPIKE_PASSWORD"
+	envServerURL    = "BWSF_SPIKE_SERVER_URL"
+	envTOTP         = "BWSF_SPIKE_TOTP"
+	envClientID     = "BWSF_SPIKE_CLIENT_ID"
+	envClientSecret = "BWSF_SPIKE_CLIENT_SECRET"
+	envIdentityURL  = "BWSF_SPIKE_IDENTITY_URL"
+
+	cloudIdentityUS = "https://identity.bitwarden.com"
+
+	// Vaultwarden rejects /connect/token when deviceName is blank.
+	// Official Bitwarden cloud is more lenient; always send device metadata.
+	spikeDeviceType       = "8" // LinuxDesktop (numeric; string names also OK on VW)
+	spikeDeviceIdentifier = "bwsf-spike-device"
+	spikeDeviceName       = "bwsf-spike"
+)
+
+func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "apikey", "--apikey":
+			if err := runScenarioB(context.Background()); err != nil {
+				fail("Scenario B", err)
+			}
+			return
+		case "help", "-h", "--help":
+			printUsage()
+			return
+		default:
+			fmt.Fprintf(os.Stderr, "unknown argument %q\n\n", os.Args[1])
+			printUsage()
+			os.Exit(2)
+		}
+	}
+
+	if err := runScenarioA(context.Background()); err != nil {
+		fail("Scenario A", err)
+	}
+}
+
+func fail(scenario string, err error) {
+	fmt.Fprintf(os.Stderr, "FAIL (%s): %v\n", scenario, err)
+	explainLoginFailure(err)
+	os.Exit(1)
+}
+
+// explainLoginFailure prints SDK error fields and a short hint when the
+// opaque "unknown status=400" pattern appears (SDK drops response bodies when
+// Vaultwarden's OAuth error JSON has an empty "error" string).
+func explainLoginFailure(err error) {
+	var bwErr *bitwarden.Error
+	if !errors.As(err, &bwErr) || bwErr == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "SDK error detail: kind=%s status=%d code=%q message=%q op=%q\n",
+		string(bwErr.Kind), bwErr.StatusCode, bwErr.Code, bwErr.Message, bwErr.Op)
+	if bwErr.Kind == bitwarden.ErrorKindUnknown && bwErr.StatusCode == 400 {
+		fmt.Fprintf(os.Stderr, "hint: opaque HTTP 400 often means Vaultwarden rejected /identity/connect/token\n")
+		fmt.Fprintf(os.Stderr, "      (e.g. missing deviceName) while SDK discarded the response body.\n")
+		fmt.Fprintf(os.Stderr, "      Ensure LoginOptions includes DeviceName/DeviceType/DeviceIdentifier.\n")
+		fmt.Fprintf(os.Stderr, "      See README.md § Vaultwarden troubleshooting.\n")
+	}
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stdout, `bwapi — Issue #53 Step 0 spike (NOT production bwsf)
+
+Usage:
+  bwapi              Run Scenario A (master-password login + vault CRUD)
+  bwapi apikey       Run Scenario B (Personal API Key → access_token probe)
+  bwapi --apikey     Same as apikey
+
+Scenario A env:
+  %s            (required)
+  %s         (required)
+  %s     (optional; self-hosted / Vaultwarden; must be https)
+  %s             (optional; 2FA authenticator code; prompts if missing)
+
+Scenario B env:
+  %s       (required)
+  %s   (required)
+  %s     (optional; derives identity as <url>/identity)
+  %s    (optional; overrides identity base)
+
+See README.md for success criteria and Vaultwarden smoke steps.
+`, envEmail, envPassword, envServerURL, envTOTP, envClientID, envClientSecret, envServerURL, envIdentityURL)
+}
+
+// ---------------------------------------------------------------------------
+// Scenario A — main go/no-go
+// ---------------------------------------------------------------------------
+
+func runScenarioA(ctx context.Context) error {
+	email := os.Getenv(envEmail)
+	password := os.Getenv(envPassword)
+	if email == "" || password == "" {
+		return fmt.Errorf("%s and %s are required", envEmail, envPassword)
+	}
+
+	opts := []bitwarden.Option{}
+	var derived identityAPIURLs
+	if serverURL := strings.TrimSpace(os.Getenv(envServerURL)); serverURL != "" {
+		normalized, err := normalizeServerURL(serverURL)
+		if err != nil {
+			return err
+		}
+		if normalized != serverURL {
+			fmt.Printf("NewClient: WithServerURL(%s)  (normalized from %q)\n", normalized, serverURL)
+		} else {
+			fmt.Printf("NewClient: WithServerURL(%s)\n", normalized)
+		}
+		derived = deriveSelfHostedURLs(normalized)
+		fmt.Printf("Derived identity=%s\n", derived.Identity)
+		fmt.Printf("Derived api=%s\n", derived.API)
+		opts = append(opts, bitwarden.WithServerURL(normalized))
+	} else {
+		fmt.Println("NewClient: cloud default (US)")
+		fmt.Printf("Identity (cloud US)=%s\n", cloudIdentityUS)
+	}
+
+	client, err := bitwarden.NewClient(opts...)
+	if err != nil {
+		return fmt.Errorf("NewClient: %w", err)
+	}
+	defer client.Close()
+
+	fmt.Printf("BeginLogin… (deviceName=%s deviceType=%s)\n", spikeDeviceName, spikeDeviceType)
+	result, err := client.BeginLogin(ctx, bitwarden.LoginOptions{
+		Email:            email,
+		Password:         password,
+		DeviceType:       spikeDeviceType,
+		DeviceIdentifier: spikeDeviceIdentifier,
+		DeviceName:       spikeDeviceName,
+	})
+	if err != nil {
+		if derived.Identity != "" {
+			diagnoseConnectToken(ctx, derived.Identity)
+		}
+		return fmt.Errorf("BeginLogin: %w", err)
+	}
+
+	if result.Challenge != nil {
+		providers := result.Challenge.Providers()
+		fmt.Printf("2FA required; providers: %v\n", providers)
+		code := strings.TrimSpace(os.Getenv(envTOTP))
+		if code == "" {
+			fmt.Print("Enter 2FA code (authenticator): ")
+			line, readErr := bufio.NewReader(os.Stdin).ReadString('\n')
+			if readErr != nil {
+				result.Challenge.Close()
+				return fmt.Errorf("read 2FA code: %w", readErr)
+			}
+			code = strings.TrimSpace(line)
+		}
+		if code == "" {
+			result.Challenge.Close()
+			return fmt.Errorf("2FA code empty (set %s or type at prompt)", envTOTP)
+		}
+		fmt.Println("CompleteLogin…")
+		result, err = client.CompleteLogin(ctx, bitwarden.CompleteLoginOptions{
+			Challenge: result.Challenge,
+			Provider:  bitwarden.TwoFactorProviderAuthenticator,
+			Code:      code,
+			Remember:  false,
+		})
+		if err != nil {
+			return fmt.Errorf("CompleteLogin: %w", err)
+		}
+	}
+
+	fmt.Printf("OK login account=%s\n", result.AccountID)
+
+	fmt.Println("Sync…")
+	if err := client.Sync(ctx); err != nil {
+		return fmt.Errorf("Sync: %w", err)
+	}
+	fmt.Println("OK Sync")
+
+	folderID, err := ensureSpikeFolder(ctx, client)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("OK folder %q id=%s\n", spikeFolderName, folderID)
+
+	if err := exerciseSecureNote(ctx, client, folderID); err != nil {
+		return err
+	}
+
+	fmt.Println("SUCCESS (Scenario A): login, sync, folder, secure-note create/get/update all OK")
+	return nil
+}
+
+func ensureSpikeFolder(ctx context.Context, client *bitwarden.Client) (string, error) {
+	folders, err := client.Folders().List(ctx)
+	if err != nil {
+		return "", fmt.Errorf("Folders.List: %w", err)
+	}
+	for _, f := range folders {
+		if f.Name == spikeFolderName {
+			fmt.Printf("Folder %q already exists\n", spikeFolderName)
+			return f.ID, nil
+		}
+	}
+	fmt.Printf("Creating folder %q…\n", spikeFolderName)
+	created, err := client.Folders().Create(ctx, spikeFolderName)
+	if err != nil {
+		return "", fmt.Errorf("Folders.Create: %w", err)
+	}
+	return created.ID, nil
+}
+
+func exerciseSecureNote(ctx context.Context, client *bitwarden.Client, folderID string) error {
+	vault := client.Vault()
+
+	fmt.Printf("Creating Secure Note %q…\n", spikeNoteName)
+	created, err := vault.Create(ctx, bitwarden.Item{
+		Type:     bitwarden.ItemTypeSecureNote,
+		Name:     spikeNoteName,
+		Notes:    "bwsf spike initial notes",
+		FolderID: folderID,
+	})
+	if err != nil {
+		return fmt.Errorf("Vault.Create(secure_note): %w", err)
+	}
+	fmt.Printf("OK create id=%s\n", created.ID)
+
+	fmt.Printf("Get by name via Search(%q)…\n", spikeNoteName)
+	found, err := vault.Search(ctx, spikeNoteName)
+	if err != nil {
+		return fmt.Errorf("Vault.Search: %w", err)
+	}
+	var got *bitwarden.Item
+	for i := range found {
+		if found[i].Name == spikeNoteName && found[i].Type == bitwarden.ItemTypeSecureNote {
+			got = &found[i]
+			break
+		}
+	}
+	if got == nil {
+		// Fallback: Get by ID from create result.
+		item, getErr := vault.Get(ctx, created.ID)
+		if getErr != nil {
+			return fmt.Errorf("secure note not found by Search and Get failed: %w", getErr)
+		}
+		got = &item
+		fmt.Println("WARN: Search did not return note; used Get by create ID")
+	}
+	fmt.Printf("OK get id=%s notes_len=%d\n", got.ID, len(got.Notes))
+
+	updatedNotes := fmt.Sprintf("bwsf spike updated at %s", time.Now().UTC().Format(time.RFC3339))
+	fmt.Println("Updating notes…")
+	updated, err := vault.Update(ctx, got.ID, bitwarden.Item{
+		Type:     bitwarden.ItemTypeSecureNote,
+		Name:     spikeNoteName,
+		Notes:    updatedNotes,
+		FolderID: folderID,
+	})
+	if err != nil {
+		return fmt.Errorf("Vault.Update: %w", err)
+	}
+	if updated.Notes != updatedNotes {
+		return fmt.Errorf("Vault.Update: notes mismatch after update")
+	}
+	fmt.Printf("OK update id=%s\n", updated.ID)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Scenario B — Personal API Key probe (SDK has no API-key login)
+// ---------------------------------------------------------------------------
+
+func runScenarioB(ctx context.Context) error {
+	clientID := os.Getenv(envClientID)
+	clientSecret := os.Getenv(envClientSecret)
+	if clientID == "" || clientSecret == "" {
+		return fmt.Errorf("%s and %s are required", envClientID, envClientSecret)
+	}
+
+	identityBase, err := resolveIdentityBase()
+	if err != nil {
+		return err
+	}
+	tokenURL := strings.TrimRight(identityBase, "/") + "/connect/token"
+	fmt.Printf("SDK gap: bitwarden-go-sdk v0.4.0 has no Personal API Key / client_credentials login.\n")
+	fmt.Printf("Probing raw HTTP POST %s\n", tokenURL)
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("scope", "api")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST connect/token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("connect/token HTTP %d: %s", resp.StatusCode, truncate(string(body), 400))
+	}
+
+	var parsed struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("decode token JSON: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return fmt.Errorf("access_token missing in response")
+	}
+
+	fmt.Printf("OK access_token obtained (type=%s expires_in=%d len=%d)\n",
+		parsed.TokenType, parsed.ExpiresIn, len(parsed.AccessToken))
+	fmt.Println("SUCCESS (Scenario B): Personal API Key → access_token (vault CRUD not required)")
+	return nil
+}
+
+func resolveIdentityBase() (string, error) {
+	if v := strings.TrimSpace(os.Getenv(envIdentityURL)); v != "" {
+		return strings.TrimRight(v, "/"), nil
+	}
+	if server := strings.TrimSpace(os.Getenv(envServerURL)); server != "" {
+		normalized, err := normalizeServerURL(server)
+		if err != nil {
+			return "", err
+		}
+		return deriveSelfHostedURLs(normalized).Identity, nil
+	}
+	return cloudIdentityUS, nil
+}
+
+type identityAPIURLs struct {
+	Identity string
+	API      string
+}
+
+// normalizeServerURL mirrors SDK self-hosted rules enough for spike DX:
+// absolute https URL, trailing slashes stripped from path.
+func normalizeServerURL(raw string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse %s: %w", envServerURL, err)
+	}
+	if !u.IsAbs() || u.Host == "" {
+		return "", fmt.Errorf("%s must be absolute URL with host", envServerURL)
+	}
+	if u.Scheme != "https" {
+		return "", fmt.Errorf("%s must use https (SDK rejects http)", envServerURL)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.Scheme + "://" + u.Host + u.Path, nil
+}
+
+func deriveSelfHostedURLs(normalizedBase string) identityAPIURLs {
+	base := strings.TrimRight(normalizedBase, "/")
+	return identityAPIURLs{
+		Identity: base + "/identity",
+		API:      base + "/api",
+	}
+}
+
+// diagnoseConnectToken probes /connect/token without the user's password so
+// PO can see Vaultwarden's JSON body (SDK often surfaces only "unknown status=400").
+func diagnoseConnectToken(ctx context.Context, identityBase string) {
+	tokenURL := strings.TrimRight(identityBase, "/") + "/connect/token"
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("username", "diagnose@example.invalid")
+	form.Set("password", "not-a-real-hash")
+	form.Set("scope", "api offline_access")
+	form.Set("client_id", "desktop")
+	form.Set("deviceType", spikeDeviceType)
+	form.Set("deviceIdentifier", spikeDeviceIdentifier)
+	form.Set("deviceName", spikeDeviceName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "diagnose: build request: %v\n", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "diagnose: POST %s: %v\n", tokenURL, err)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	fmt.Fprintf(os.Stderr, "diagnose: POST %s → HTTP %d\n", tokenURL, resp.StatusCode)
+	fmt.Fprintf(os.Stderr, "diagnose: body=%s\n", truncate(string(body), 500))
+
+	// Also show what missing deviceName looks like (common VW 400).
+	form.Del("deviceName")
+	req2, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return
+	}
+	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req2.Header.Set("Accept", "application/json")
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		return
+	}
+	defer resp2.Body.Close()
+	body2, _ := io.ReadAll(io.LimitReader(resp2.Body, 1<<16))
+	fmt.Fprintf(os.Stderr, "diagnose (no deviceName): HTTP %d body=%s\n", resp2.StatusCode, truncate(string(body2), 300))
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/app/spike/bwapi/main.go
+++ b/app/spike/bwapi/main.go
@@ -307,18 +307,26 @@ func runScenarioB(ctx context.Context) error {
 	tokenURL := strings.TrimRight(identityBase, "/") + "/connect/token"
 	fmt.Printf("SDK gap: bitwarden-go-sdk v0.4.0 has no Personal API Key / client_credentials login.\n")
 	fmt.Printf("Probing raw HTTP POST %s\n", tokenURL)
+	fmt.Printf("Device metadata: deviceName=%s deviceType=%s deviceIdentifier=%s\n",
+		spikeDeviceName, spikeDeviceType, spikeDeviceIdentifier)
 
+	// Vaultwarden requires device_* on client_credentials (same as password grant).
+	// Form names match Bitwarden CLI / Scenario A (camelCase; VW also accepts snake_case).
 	form := url.Values{}
 	form.Set("grant_type", "client_credentials")
 	form.Set("client_id", clientID)
 	form.Set("client_secret", clientSecret)
 	form.Set("scope", "api")
+	form.Set("deviceIdentifier", spikeDeviceIdentifier)
+	form.Set("deviceName", spikeDeviceName)
+	form.Set("deviceType", spikeDeviceType)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/app/spike/bwapi/run.sh
+++ b/app/spike/bwapi/run.sh
@@ -36,8 +36,17 @@ if [[ -n "${GOENV_VER}" ]]; then
   echo "run.sh: GOENV_VERSION=${GOENV_VERSION} GOTOOLCHAIN=${GOTOOLCHAIN}" >&2
 fi
 
+# With no args: run this package.
+# Known go subcommands (build, mod, …) pass through: ./run.sh build -o /tmp/bwapi .
+# Anything else is forwarded as program args: ./run.sh apikey → go run . apikey
 if [[ $# -eq 0 ]]; then
   set -- run .
+elif [[ "$1" != "run" && "$1" != "build" && "$1" != "mod" && "$1" != "test" &&
+        "$1" != "env" && "$1" != "version" && "$1" != "get" && "$1" != "install" &&
+        "$1" != "list" && "$1" != "fmt" && "$1" != "vet" && "$1" != "generate" &&
+        "$1" != "clean" && "$1" != "work" && "$1" != "tool" && "$1" != "doc" &&
+        "$1" != "fix" ]]; then
+  set -- run . "$@"
 fi
 
 exec go "$@"

--- a/app/spike/bwapi/run.sh
+++ b/app/spike/bwapi/run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Bypass goenv's go.mod "go 1.26" check when 1.26 is not installed locally.
+# Uses an installed goenv version + GOTOOLCHAIN=auto so the Go toolchain
+# downloads 1.26 as needed.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+pick_goenv_version() {
+  if [[ -n "${GOENV_VERSION:-}" ]]; then
+    echo "$GOENV_VERSION"
+    return
+  fi
+  if ! command -v goenv >/dev/null 2>&1; then
+    return
+  fi
+  # Prefer newest installed 1.25.x, else any installed version (skip system).
+  local versions
+  versions="$(goenv versions --bare 2>/dev/null || true)"
+  if [[ -z "$versions" ]]; then
+    return
+  fi
+  local v
+  v="$(echo "$versions" | grep -E '^1\.25\.' | sort -V | tail -1 || true)"
+  if [[ -z "$v" ]]; then
+    v="$(echo "$versions" | grep -v '^system$' | sort -V | tail -1 || true)"
+  fi
+  echo "$v"
+}
+
+GOENV_VER="$(pick_goenv_version || true)"
+export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
+
+if [[ -n "${GOENV_VER}" ]]; then
+  export GOENV_VERSION="$GOENV_VER"
+  echo "run.sh: GOENV_VERSION=${GOENV_VERSION} GOTOOLCHAIN=${GOTOOLCHAIN}" >&2
+fi
+
+if [[ $# -eq 0 ]]; then
+  set -- run .
+fi
+
+exec go "$@"


### PR DESCRIPTION
## Summary
- Issue #53 Step 0 向けの使い捨てスパイク CLI を `app/spike/bwapi/` に追加（本番 `bwsf` / `app/go.mod` とは分離）
- コミュニティ Go SDK（`bnema/bitwarden-go-sdk`）での vault CRUD（Scenario A）と Personal API Key の raw HTTP プローブ（Scenario B）を検証
- Vaultwarden セルフホスト向けスモーク（device メタ必須など）を実施し成功を確認

## Test plan
- [ ] `cd app/spike/bwapi && ./run.sh build -o /tmp/bwapi .` でコンパイルできること
- [ ] （任意）Scenario A: `BWSF_SPIKE_EMAIL` / `BWSF_SPIKE_PASSWORD`（必要なら `BWSF_SPIKE_SERVER_URL` / `BWSF_SPIKE_TOTP`）を設定して `./run.sh` → `SUCCESS (Scenario A)`
- [ ] （任意）Scenario B: `BWSF_SPIKE_CLIENT_ID` / `BWSF_SPIKE_CLIENT_SECRET` を設定して `./run.sh apikey` → `SUCCESS (Scenario B)`
- [ ] シークレットがリポジトリに含まれていないこと

Closes #53 is not intended — tracking only: #53

Made with [Cursor](https://cursor.com)