### PR TITLE
feat: backend adapter foundation (Issue #53 Step 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Simple usage below:
 | bwsf push | .env files push to your Bitwarden host |
 | bwsf pull | .env files pull from your Bitwarden host |
 | bwsf list | Show list stored .env files at your Bitwarden host |
+| bwsf backend | Show or set Bitwarden backend (`bw` CLI or `api`) |
 
 ## Motivation
 
@@ -116,6 +117,16 @@ bwsf list
 
 List up your .env datas from Bitwarden host.
 They will showed up project names list on stdout.
+
+### Show or set Bitwarden backend
+
+```shell
+bwsf backend
+bwsf backend --set bw
+bwsf backend --set api
+```
+
+Default backend is `bw` (Bitwarden CLI). The `api` backend is experimental and not fully implemented yet.
 
 ## Uninstall
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -46,6 +46,7 @@ bwsfコマンドは、Bitwardenで管理されているdotenvファイルをサ�
 | bwsf push | .envファイルをBitwardenホストにプッシュ |
 | bwsf pull | Bitwardenホストから.envファイルをプル |
 | bwsf list | Bitwardenホストに保存されている.envファイルの一覧を表示 |
+| bwsf backend | Bitwardenバックエンド（`bw` CLI / `api`）の表示・設定 |
 
 ## 動機
 
@@ -115,6 +116,16 @@ bwsf list
 
 Bitwardenホストから.envデータの一覧を取得します。
 プロジェクト名のリストが標準出力に表示されます。
+
+### Bitwardenバックエンドの表示・設定
+
+```shell
+bwsf backend
+bwsf backend --set bw
+bwsf backend --set api
+```
+
+デフォルトは `bw`（Bitwarden CLI）です。`api` バックエンドは実験的で、まだ完全には実装されていません。
 
 ## アンインストール
 

--- a/app/spike/bwapi/Makefile
+++ b/app/spike/bwapi/Makefile
@@ -7,7 +7,7 @@ build:
 	./run.sh build -o /tmp/bwapi .
 
 run:
-	./run.sh run .
+	./run.sh
 
 tidy:
 	./run.sh mod tidy

--- a/app/spike/bwapi/Makefile
+++ b/app/spike/bwapi/Makefile
@@ -1,0 +1,13 @@
+# Spike helper: goenv may reject go.mod's "go 1.26" before GOTOOLCHAIN runs.
+# Prefer: ./run.sh  or  make build / make run
+
+.PHONY: build run tidy
+
+build:
+	./run.sh build -o /tmp/bwapi .
+
+run:
+	./run.sh run .
+
+tidy:
+	./run.sh mod tidy

--- a/app/spike/bwapi/README.md
+++ b/app/spike/bwapi/README.md
@@ -66,13 +66,14 @@ export BWSF_SPIKE_EMAIL='you@example.com'
 export BWSF_SPIKE_PASSWORD='…'
 # 任意: export BWSF_SPIKE_SERVER_URL='https://your-server'
 # 任意: export BWSF_SPIKE_TOTP='123456'
-./run.sh run .
-# または: make run
+./run.sh
+# または: make run / ./run.sh run .
 
 # Scenario B（ライブ）
 export BWSF_SPIKE_CLIENT_ID='user.…'
 export BWSF_SPIKE_CLIENT_SECRET='…'
-./run.sh run . apikey
+./run.sh apikey
+# または: ./run.sh run . apikey
 ```
 
 手動で同じことをする場合（このマシンで確認済み）:
@@ -110,7 +111,7 @@ stdout に次が揃うこと:
 
 ### Scenario B
 
-- Identity `POST …/connect/token`（`grant_type=client_credentials`, `scope=api`）で **`access_token` 取得**
+- Identity `POST …/connect/token`（`grant_type=client_credentials`, `scope=api` + device メタ）で **`access_token` 取得**
 - vault CRUD は不要
 - SDK に API Key ログインが無いため、スパイクは raw HTTP でプローブする
 
@@ -144,22 +145,25 @@ stdout に次が揃うこと:
 
 よくある原因（このスパイクで確認済み）:
 
-1. **`deviceName` 未送信** — Vaultwarden は `/identity/connect/token` で `device_name cannot be blank` を返す。  
-   公式 cloud より厳しい。スパイクは常に `DeviceName` / `DeviceType` / `DeviceIdentifier` を付ける。
+1. **デバイスメタ未送信** — Vaultwarden は `/identity/connect/token` で空白を拒否する。  
+   - Scenario A（password）: `device_name cannot be blank`  
+   - Scenario B（`client_credentials`）: `device_identifier cannot be blank`（続けて name / type も必須）  
+   公式 cloud より厳しい。スパイクは常に `deviceIdentifier` / `deviceName` / `deviceType` を付ける（A は SDK `LoginOptions`、B は raw form）。
 2. **SDK がボディを捨てる** — VW の 400 JSON は `"error":""`（空文字）になりがちで、SDK は OAuth の `error` が空だと `KindUnknown` + `status=400` だけにする。本物の理由は `message` / `errorModel.message` 側。
 3. **認証失敗も同じ opaque 400** — パスワード不正時も VW は同様の形のため、SDK 上は `unknown status=400` に見えることがある。
 
 失敗時のスパイク出力:
 
 - 導出済み `identity` / `api` URL
-- SDK `Error` の kind / status / code / message
-- パスワードを使わない diagnose POST（`deviceName` あり／なし）でレスポンスボディ例を表示
+- SDK `Error` の kind / status / code / message（Scenario A）
+- パスワードを使わない diagnose POST（`deviceName` あり／なし）でレスポンスボディ例を表示（Scenario A）
+- Scenario B は raw HTTP のため、失敗時にレスポンスボディをそのまま表示
 
 ### VW API 不一致 vs 設定ミス
 
 | 症状 | 解釈 |
 |------|------|
-| prelogin 200、token で `device_name cannot be blank` | **設定／クライアント側**（デバイスメタ不足）。修正可能 |
+| prelogin 200、token で `device_name` / `device_identifier cannot be blank` | **設定／クライアント側**（デバイスメタ不足）。修正可能 |
 | prelogin / identity が 404 | ベース URL 誤り、またはリバースプロキシで `/identity` が届いていない |
 | token が常に opaque 400 で diagnose も意味不明 | **VW と SDK の API 差**の可能性。Issue に diagnose 全文を貼る |
 
@@ -179,7 +183,7 @@ stdout に次が揃うこと:
 
 - **Personal API Key:** `bitwarden-go-sdk` v0.4.0 に client_credentials / API Key ログイン API なし → Scenario B は raw HTTP。
 - **Vaultwarden:** README で non-goal。加えて **HTTPS 必須**（ローカル HTTP VW はそのままでは `NewClient(WithServerURL)` 不可）。
-- **deviceName 必須 (VW):** SDK は `LoginOptions.DeviceName` が空だと form に載せない。VW は 400 `device_name cannot be blank`。スパイクは固定デバイスメタを送る。
+- **device メタ必須 (VW):** password / client_credentials とも `deviceIdentifier`・`deviceName`・`deviceType` が必要。SDK は `LoginOptions` が空だと form に載せない。スパイクは固定デバイスメタを送る。
 - **opaque 400:** VW の token エラー JSON は `"error":""` が多く、SDK がボディを捨てて `unknown status=400` になる。失敗時は diagnose 出力を参照。
 - **2FA:** `CompleteLogin` + `TwoFactorProviderAuthenticator`。他プロバイダは要コード変更。
 - alpha API は破壊的変更があり得る。

--- a/app/spike/bwapi/README.md
+++ b/app/spike/bwapi/README.md
@@ -1,0 +1,185 @@
+# bwapi — Issue #53 Step 0 spike
+
+本番の `bwsf` CLI とは **別モジュール・別バイナリ** の使い捨て実験です。  
+`app/go.mod` や `app/src/` には SDK を入れず、コミュニティ Go SDK  
+[`github.com/bnema/bitwarden-go-sdk`](https://github.com/bnema/bitwarden-go-sdk)（v0.4.x）で vault 操作が通るかだけを検証します。
+
+> **注意:** SDK は alpha。公式サポートは Bitwarden cloud / 公式 self-hosted のみで、**Vaultwarden は非目標**と明記されています。HTTPS 必須（`http://` は SDK が拒否）。
+
+---
+
+## 必要な環境変数
+
+### Scenario A（メイン go/no-go）
+
+| 変数 | 必須 | 説明 |
+|------|------|------|
+| `BWSF_SPIKE_EMAIL` | ○ | ログイン用メール |
+| `BWSF_SPIKE_PASSWORD` | ○ | マスターパスワード |
+| `BWSF_SPIKE_SERVER_URL` | − | セルフホスト / Vaultwarden のベース URL（例: `https://vw.example.com`、末尾 `/` 可）。未設定時は Bitwarden US cloud。SDK は `{url}/identity` と `{url}/api` に導出 |
+| `BWSF_SPIKE_TOTP` | − | 2FA が必要な場合の authenticator コード。未設定なら対話プロンプト |
+
+### Scenario B（Personal API Key プローブ）
+
+| 変数 | 必須 | 説明 |
+|------|------|------|
+| `BWSF_SPIKE_CLIENT_ID` | ○ | Personal API Key の `client_id`（例: `user.…`） |
+| `BWSF_SPIKE_CLIENT_SECRET` | ○ | Personal API Key の `client_secret` |
+| `BWSF_SPIKE_SERVER_URL` | − | 設定時は Identity を `<url>/identity` と導出 |
+| `BWSF_SPIKE_IDENTITY_URL` | − | Identity ベース URL の上書き（未設定時: cloud は `https://identity.bitwarden.com`） |
+
+シークレットをコードや git に書かないこと。
+
+---
+
+## ビルド・実行
+
+SDK は **Go 1.26+** を要求します（`go.mod` の `go 1.26`）。
+
+### goenv 注意（このマシン）
+
+goenv は `go.mod` の `go 1.26` を見て **GOTOOLCHAIN より先に** バージョン解決します。  
+`goenv versions` に 1.26 が無いと、次で失敗します:
+
+```text
+goenv: version '1.26' is not installed
+```
+
+インストール済みは例: `1.25.7`（global）。対処は次のどちらか。
+
+#### 推奨: `./run.sh`（GOENV_VERSION + GOTOOLCHAIN=auto）
+
+`run.sh` がインストール済みの 1.25.x を検出し、`GOENV_VERSION` と `GOTOOLCHAIN=auto` を付けて `go` を呼びます（toolchain が 1.26 を取得）。
+
+```bash
+cd app/spike/bwapi
+
+# 依存整理
+./run.sh mod tidy
+
+# コンパイル確認（認証情報なしで OK）
+./run.sh build -o /tmp/bwapi .
+# または: make build
+
+# Scenario A（ライブ）
+export BWSF_SPIKE_EMAIL='you@example.com'
+export BWSF_SPIKE_PASSWORD='…'
+# 任意: export BWSF_SPIKE_SERVER_URL='https://your-server'
+# 任意: export BWSF_SPIKE_TOTP='123456'
+./run.sh run .
+# または: make run
+
+# Scenario B（ライブ）
+export BWSF_SPIKE_CLIENT_ID='user.…'
+export BWSF_SPIKE_CLIENT_SECRET='…'
+./run.sh run . apikey
+```
+
+手動で同じことをする場合（このマシンで確認済み）:
+
+```bash
+cd app/spike/bwapi
+GOENV_VERSION=1.25.7 GOTOOLCHAIN=auto go build -o /tmp/bwapi .
+GOENV_VERSION=1.25.7 GOTOOLCHAIN=auto go run .
+```
+
+#### 代替: goenv に 1.26 を入れる
+
+```bash
+goenv install 1.26
+cd app/spike/bwapi
+go run .   # または GOTOOLCHAIN=auto go run .
+```
+
+本番 `make build` / Dockerfile / brew には **含まれません**。
+
+---
+
+## 成功条件
+
+### Scenario A（go/no-go）
+
+stdout に次が揃うこと:
+
+1. `NewClient` 成功（cloud または `WithServerURL`）
+2. `BeginLogin`（必要なら `CompleteLogin`）成功
+3. `Sync` 成功
+4. フォルダ `bwsf-spike` が既存 or 新規作成
+5. Secure Note `bwsf-spike-note` の create → get/search → notes update 成功
+6. 最後に `SUCCESS (Scenario A): …`
+
+### Scenario B
+
+- Identity `POST …/connect/token`（`grant_type=client_credentials`, `scope=api`）で **`access_token` 取得**
+- vault CRUD は不要
+- SDK に API Key ログインが無いため、スパイクは raw HTTP でプローブする
+
+### Scenario C（PO Vaultwarden スモーク）
+
+1. Vaultwarden を **HTTPS** で用意（SDK は `http://` を拒否）
+2. `export BWSF_SPIKE_SERVER_URL='https://<your-vaultwarden>'`
+3. A と同じく email / password を設定し `go run .` を実行
+4. 結果（成功 / 失敗メッセージ全文）を Issue #53 に報告
+
+公式には VW 非対応のため、失敗してもスパイクの価値あり（制約の実証）。
+
+---
+
+## Vaultwarden troubleshooting
+
+### 期待する URL 形
+
+`BWSF_SPIKE_SERVER_URL=https://vw.example.com`（末尾スラッシュはスパイク／SDK が除去）のとき:
+
+| 用途 | URL |
+|------|-----|
+| Identity | `https://vw.example.com/identity` |
+| API | `https://vw.example.com/api` |
+| Prelogin | `POST …/identity/accounts/prelogin/password` |
+| Token | `POST …/identity/connect/token` |
+
+末尾 `/` だけでは 400 にはなりません。SDK の `NewSelfHosted` が path の trailing slash を strip します。
+
+### `BeginLogin: bitwarden: unknown status=400`
+
+よくある原因（このスパイクで確認済み）:
+
+1. **`deviceName` 未送信** — Vaultwarden は `/identity/connect/token` で `device_name cannot be blank` を返す。  
+   公式 cloud より厳しい。スパイクは常に `DeviceName` / `DeviceType` / `DeviceIdentifier` を付ける。
+2. **SDK がボディを捨てる** — VW の 400 JSON は `"error":""`（空文字）になりがちで、SDK は OAuth の `error` が空だと `KindUnknown` + `status=400` だけにする。本物の理由は `message` / `errorModel.message` 側。
+3. **認証失敗も同じ opaque 400** — パスワード不正時も VW は同様の形のため、SDK 上は `unknown status=400` に見えることがある。
+
+失敗時のスパイク出力:
+
+- 導出済み `identity` / `api` URL
+- SDK `Error` の kind / status / code / message
+- パスワードを使わない diagnose POST（`deviceName` あり／なし）でレスポンスボディ例を表示
+
+### VW API 不一致 vs 設定ミス
+
+| 症状 | 解釈 |
+|------|------|
+| prelogin 200、token で `device_name cannot be blank` | **設定／クライアント側**（デバイスメタ不足）。修正可能 |
+| prelogin / identity が 404 | ベース URL 誤り、またはリバースプロキシで `/identity` が届いていない |
+| token が常に opaque 400 で diagnose も意味不明 | **VW と SDK の API 差**の可能性。Issue に diagnose 全文を貼る |
+
+---
+
+## Identity URL の導出（Scenario B）
+
+| 条件 | Identity base | token endpoint |
+|------|---------------|----------------|
+| `BWSF_SPIKE_IDENTITY_URL` あり | その値 | `{base}/connect/token` |
+| `BWSF_SPIKE_SERVER_URL` あり | `{server}/identity` | `{server}/identity/connect/token` |
+| どちらも無し（cloud US） | `https://identity.bitwarden.com` | `…/connect/token` |
+
+---
+
+## 既知の SDK / 運用ギャップ（実装時メモ）
+
+- **Personal API Key:** `bitwarden-go-sdk` v0.4.0 に client_credentials / API Key ログイン API なし → Scenario B は raw HTTP。
+- **Vaultwarden:** README で non-goal。加えて **HTTPS 必須**（ローカル HTTP VW はそのままでは `NewClient(WithServerURL)` 不可）。
+- **deviceName 必須 (VW):** SDK は `LoginOptions.DeviceName` が空だと form に載せない。VW は 400 `device_name cannot be blank`。スパイクは固定デバイスメタを送る。
+- **opaque 400:** VW の token エラー JSON は `"error":""` が多く、SDK がボディを捨てて `unknown status=400` になる。失敗時は diagnose 出力を参照。
+- **2FA:** `CompleteLogin` + `TwoFactorProviderAuthenticator`。他プロバイダは要コード変更。
+- alpha API は破壊的変更があり得る。

--- a/app/spike/bwapi/go.mod
+++ b/app/spike/bwapi/go.mod
@@ -1,0 +1,10 @@
+module github.com/b4m-oss/bwsf/app/spike/bwapi
+
+go 1.26
+
+require github.com/bnema/bitwarden-go-sdk v0.4.0
+
+require (
+	golang.org/x/crypto v0.50.0 // indirect
+	golang.org/x/sys v0.43.0 // indirect
+)

--- a/app/spike/bwapi/go.sum
+++ b/app/spike/bwapi/go.sum
@@ -1,0 +1,16 @@
+github.com/bnema/bitwarden-go-sdk v0.4.0 h1:O7zAWX/++bZl5WDwZ5Fa8OKnBtkuJe9xDK1+7dN6CQo=
+github.com/bnema/bitwarden-go-sdk v0.4.0/go.mod h1:z9ZZyeUnDC1CZ/TwboEJ7fsaEmLwnqWIozdbkG5+JCY=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
+golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/app/spike/bwapi/main.go
+++ b/app/spike/bwapi/main.go
@@ -1,0 +1,455 @@
+// Command bwapi is a disposable spike CLI for Issue #53 Step 0.
+// It is NOT part of the production bwsf binary.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bnema/bitwarden-go-sdk/bitwarden"
+)
+
+const (
+	spikeFolderName = "bwsf-spike"
+	spikeNoteName   = "bwsf-spike-note"
+
+	envEmail        = "BWSF_SPIKE_EMAIL"
+	envPassword     = "BWSF_SPIKE_PASSWORD"
+	envServerURL    = "BWSF_SPIKE_SERVER_URL"
+	envTOTP         = "BWSF_SPIKE_TOTP"
+	envClientID     = "BWSF_SPIKE_CLIENT_ID"
+	envClientSecret = "BWSF_SPIKE_CLIENT_SECRET"
+	envIdentityURL  = "BWSF_SPIKE_IDENTITY_URL"
+
+	cloudIdentityUS = "https://identity.bitwarden.com"
+
+	// Vaultwarden rejects /connect/token when deviceName is blank.
+	// Official Bitwarden cloud is more lenient; always send device metadata.
+	spikeDeviceType       = "8" // LinuxDesktop (numeric; string names also OK on VW)
+	spikeDeviceIdentifier = "bwsf-spike-device"
+	spikeDeviceName       = "bwsf-spike"
+)
+
+func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "apikey", "--apikey":
+			if err := runScenarioB(context.Background()); err != nil {
+				fail("Scenario B", err)
+			}
+			return
+		case "help", "-h", "--help":
+			printUsage()
+			return
+		default:
+			fmt.Fprintf(os.Stderr, "unknown argument %q\n\n", os.Args[1])
+			printUsage()
+			os.Exit(2)
+		}
+	}
+
+	if err := runScenarioA(context.Background()); err != nil {
+		fail("Scenario A", err)
+	}
+}
+
+func fail(scenario string, err error) {
+	fmt.Fprintf(os.Stderr, "FAIL (%s): %v\n", scenario, err)
+	explainLoginFailure(err)
+	os.Exit(1)
+}
+
+// explainLoginFailure prints SDK error fields and a short hint when the
+// opaque "unknown status=400" pattern appears (SDK drops response bodies when
+// Vaultwarden's OAuth error JSON has an empty "error" string).
+func explainLoginFailure(err error) {
+	var bwErr *bitwarden.Error
+	if !errors.As(err, &bwErr) || bwErr == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "SDK error detail: kind=%s status=%d code=%q message=%q op=%q\n",
+		string(bwErr.Kind), bwErr.StatusCode, bwErr.Code, bwErr.Message, bwErr.Op)
+	if bwErr.Kind == bitwarden.ErrorKindUnknown && bwErr.StatusCode == 400 {
+		fmt.Fprintf(os.Stderr, "hint: opaque HTTP 400 often means Vaultwarden rejected /identity/connect/token\n")
+		fmt.Fprintf(os.Stderr, "      (e.g. missing deviceName) while SDK discarded the response body.\n")
+		fmt.Fprintf(os.Stderr, "      Ensure LoginOptions includes DeviceName/DeviceType/DeviceIdentifier.\n")
+		fmt.Fprintf(os.Stderr, "      See README.md § Vaultwarden troubleshooting.\n")
+	}
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stdout, `bwapi — Issue #53 Step 0 spike (NOT production bwsf)
+
+Usage:
+  bwapi              Run Scenario A (master-password login + vault CRUD)
+  bwapi apikey       Run Scenario B (Personal API Key → access_token probe)
+  bwapi --apikey     Same as apikey
+
+Scenario A env:
+  %s            (required)
+  %s         (required)
+  %s     (optional; self-hosted / Vaultwarden; must be https)
+  %s             (optional; 2FA authenticator code; prompts if missing)
+
+Scenario B env:
+  %s       (required)
+  %s   (required)
+  %s     (optional; derives identity as <url>/identity)
+  %s    (optional; overrides identity base)
+
+See README.md for success criteria and Vaultwarden smoke steps.
+`, envEmail, envPassword, envServerURL, envTOTP, envClientID, envClientSecret, envServerURL, envIdentityURL)
+}
+
+// ---------------------------------------------------------------------------
+// Scenario A — main go/no-go
+// ---------------------------------------------------------------------------
+
+func runScenarioA(ctx context.Context) error {
+	email := os.Getenv(envEmail)
+	password := os.Getenv(envPassword)
+	if email == "" || password == "" {
+		return fmt.Errorf("%s and %s are required", envEmail, envPassword)
+	}
+
+	opts := []bitwarden.Option{}
+	var derived identityAPIURLs
+	if serverURL := strings.TrimSpace(os.Getenv(envServerURL)); serverURL != "" {
+		normalized, err := normalizeServerURL(serverURL)
+		if err != nil {
+			return err
+		}
+		if normalized != serverURL {
+			fmt.Printf("NewClient: WithServerURL(%s)  (normalized from %q)\n", normalized, serverURL)
+		} else {
+			fmt.Printf("NewClient: WithServerURL(%s)\n", normalized)
+		}
+		derived = deriveSelfHostedURLs(normalized)
+		fmt.Printf("Derived identity=%s\n", derived.Identity)
+		fmt.Printf("Derived api=%s\n", derived.API)
+		opts = append(opts, bitwarden.WithServerURL(normalized))
+	} else {
+		fmt.Println("NewClient: cloud default (US)")
+		fmt.Printf("Identity (cloud US)=%s\n", cloudIdentityUS)
+	}
+
+	client, err := bitwarden.NewClient(opts...)
+	if err != nil {
+		return fmt.Errorf("NewClient: %w", err)
+	}
+	defer client.Close()
+
+	fmt.Printf("BeginLogin… (deviceName=%s deviceType=%s)\n", spikeDeviceName, spikeDeviceType)
+	result, err := client.BeginLogin(ctx, bitwarden.LoginOptions{
+		Email:            email,
+		Password:         password,
+		DeviceType:       spikeDeviceType,
+		DeviceIdentifier: spikeDeviceIdentifier,
+		DeviceName:       spikeDeviceName,
+	})
+	if err != nil {
+		if derived.Identity != "" {
+			diagnoseConnectToken(ctx, derived.Identity)
+		}
+		return fmt.Errorf("BeginLogin: %w", err)
+	}
+
+	if result.Challenge != nil {
+		providers := result.Challenge.Providers()
+		fmt.Printf("2FA required; providers: %v\n", providers)
+		code := strings.TrimSpace(os.Getenv(envTOTP))
+		if code == "" {
+			fmt.Print("Enter 2FA code (authenticator): ")
+			line, readErr := bufio.NewReader(os.Stdin).ReadString('\n')
+			if readErr != nil {
+				result.Challenge.Close()
+				return fmt.Errorf("read 2FA code: %w", readErr)
+			}
+			code = strings.TrimSpace(line)
+		}
+		if code == "" {
+			result.Challenge.Close()
+			return fmt.Errorf("2FA code empty (set %s or type at prompt)", envTOTP)
+		}
+		fmt.Println("CompleteLogin…")
+		result, err = client.CompleteLogin(ctx, bitwarden.CompleteLoginOptions{
+			Challenge: result.Challenge,
+			Provider:  bitwarden.TwoFactorProviderAuthenticator,
+			Code:      code,
+			Remember:  false,
+		})
+		if err != nil {
+			return fmt.Errorf("CompleteLogin: %w", err)
+		}
+	}
+
+	fmt.Printf("OK login account=%s\n", result.AccountID)
+
+	fmt.Println("Sync…")
+	if err := client.Sync(ctx); err != nil {
+		return fmt.Errorf("Sync: %w", err)
+	}
+	fmt.Println("OK Sync")
+
+	folderID, err := ensureSpikeFolder(ctx, client)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("OK folder %q id=%s\n", spikeFolderName, folderID)
+
+	if err := exerciseSecureNote(ctx, client, folderID); err != nil {
+		return err
+	}
+
+	fmt.Println("SUCCESS (Scenario A): login, sync, folder, secure-note create/get/update all OK")
+	return nil
+}
+
+func ensureSpikeFolder(ctx context.Context, client *bitwarden.Client) (string, error) {
+	folders, err := client.Folders().List(ctx)
+	if err != nil {
+		return "", fmt.Errorf("Folders.List: %w", err)
+	}
+	for _, f := range folders {
+		if f.Name == spikeFolderName {
+			fmt.Printf("Folder %q already exists\n", spikeFolderName)
+			return f.ID, nil
+		}
+	}
+	fmt.Printf("Creating folder %q…\n", spikeFolderName)
+	created, err := client.Folders().Create(ctx, spikeFolderName)
+	if err != nil {
+		return "", fmt.Errorf("Folders.Create: %w", err)
+	}
+	return created.ID, nil
+}
+
+func exerciseSecureNote(ctx context.Context, client *bitwarden.Client, folderID string) error {
+	vault := client.Vault()
+
+	fmt.Printf("Creating Secure Note %q…\n", spikeNoteName)
+	created, err := vault.Create(ctx, bitwarden.Item{
+		Type:     bitwarden.ItemTypeSecureNote,
+		Name:     spikeNoteName,
+		Notes:    "bwsf spike initial notes",
+		FolderID: folderID,
+	})
+	if err != nil {
+		return fmt.Errorf("Vault.Create(secure_note): %w", err)
+	}
+	fmt.Printf("OK create id=%s\n", created.ID)
+
+	fmt.Printf("Get by name via Search(%q)…\n", spikeNoteName)
+	found, err := vault.Search(ctx, spikeNoteName)
+	if err != nil {
+		return fmt.Errorf("Vault.Search: %w", err)
+	}
+	var got *bitwarden.Item
+	for i := range found {
+		if found[i].Name == spikeNoteName && found[i].Type == bitwarden.ItemTypeSecureNote {
+			got = &found[i]
+			break
+		}
+	}
+	if got == nil {
+		// Fallback: Get by ID from create result.
+		item, getErr := vault.Get(ctx, created.ID)
+		if getErr != nil {
+			return fmt.Errorf("secure note not found by Search and Get failed: %w", getErr)
+		}
+		got = &item
+		fmt.Println("WARN: Search did not return note; used Get by create ID")
+	}
+	fmt.Printf("OK get id=%s notes_len=%d\n", got.ID, len(got.Notes))
+
+	updatedNotes := fmt.Sprintf("bwsf spike updated at %s", time.Now().UTC().Format(time.RFC3339))
+	fmt.Println("Updating notes…")
+	updated, err := vault.Update(ctx, got.ID, bitwarden.Item{
+		Type:     bitwarden.ItemTypeSecureNote,
+		Name:     spikeNoteName,
+		Notes:    updatedNotes,
+		FolderID: folderID,
+	})
+	if err != nil {
+		return fmt.Errorf("Vault.Update: %w", err)
+	}
+	if updated.Notes != updatedNotes {
+		return fmt.Errorf("Vault.Update: notes mismatch after update")
+	}
+	fmt.Printf("OK update id=%s\n", updated.ID)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Scenario B — Personal API Key probe (SDK has no API-key login)
+// ---------------------------------------------------------------------------
+
+func runScenarioB(ctx context.Context) error {
+	clientID := os.Getenv(envClientID)
+	clientSecret := os.Getenv(envClientSecret)
+	if clientID == "" || clientSecret == "" {
+		return fmt.Errorf("%s and %s are required", envClientID, envClientSecret)
+	}
+
+	identityBase, err := resolveIdentityBase()
+	if err != nil {
+		return err
+	}
+	tokenURL := strings.TrimRight(identityBase, "/") + "/connect/token"
+	fmt.Printf("SDK gap: bitwarden-go-sdk v0.4.0 has no Personal API Key / client_credentials login.\n")
+	fmt.Printf("Probing raw HTTP POST %s\n", tokenURL)
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("scope", "api")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST connect/token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("connect/token HTTP %d: %s", resp.StatusCode, truncate(string(body), 400))
+	}
+
+	var parsed struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("decode token JSON: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return fmt.Errorf("access_token missing in response")
+	}
+
+	fmt.Printf("OK access_token obtained (type=%s expires_in=%d len=%d)\n",
+		parsed.TokenType, parsed.ExpiresIn, len(parsed.AccessToken))
+	fmt.Println("SUCCESS (Scenario B): Personal API Key → access_token (vault CRUD not required)")
+	return nil
+}
+
+func resolveIdentityBase() (string, error) {
+	if v := strings.TrimSpace(os.Getenv(envIdentityURL)); v != "" {
+		return strings.TrimRight(v, "/"), nil
+	}
+	if server := strings.TrimSpace(os.Getenv(envServerURL)); server != "" {
+		normalized, err := normalizeServerURL(server)
+		if err != nil {
+			return "", err
+		}
+		return deriveSelfHostedURLs(normalized).Identity, nil
+	}
+	return cloudIdentityUS, nil
+}
+
+type identityAPIURLs struct {
+	Identity string
+	API      string
+}
+
+// normalizeServerURL mirrors SDK self-hosted rules enough for spike DX:
+// absolute https URL, trailing slashes stripped from path.
+func normalizeServerURL(raw string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse %s: %w", envServerURL, err)
+	}
+	if !u.IsAbs() || u.Host == "" {
+		return "", fmt.Errorf("%s must be absolute URL with host", envServerURL)
+	}
+	if u.Scheme != "https" {
+		return "", fmt.Errorf("%s must use https (SDK rejects http)", envServerURL)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.Scheme + "://" + u.Host + u.Path, nil
+}
+
+func deriveSelfHostedURLs(normalizedBase string) identityAPIURLs {
+	base := strings.TrimRight(normalizedBase, "/")
+	return identityAPIURLs{
+		Identity: base + "/identity",
+		API:      base + "/api",
+	}
+}
+
+// diagnoseConnectToken probes /connect/token without the user's password so
+// PO can see Vaultwarden's JSON body (SDK often surfaces only "unknown status=400").
+func diagnoseConnectToken(ctx context.Context, identityBase string) {
+	tokenURL := strings.TrimRight(identityBase, "/") + "/connect/token"
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("username", "diagnose@example.invalid")
+	form.Set("password", "not-a-real-hash")
+	form.Set("scope", "api offline_access")
+	form.Set("client_id", "desktop")
+	form.Set("deviceType", spikeDeviceType)
+	form.Set("deviceIdentifier", spikeDeviceIdentifier)
+	form.Set("deviceName", spikeDeviceName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "diagnose: build request: %v\n", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "diagnose: POST %s: %v\n", tokenURL, err)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	fmt.Fprintf(os.Stderr, "diagnose: POST %s → HTTP %d\n", tokenURL, resp.StatusCode)
+	fmt.Fprintf(os.Stderr, "diagnose: body=%s\n", truncate(string(body), 500))
+
+	// Also show what missing deviceName looks like (common VW 400).
+	form.Del("deviceName")
+	req2, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return
+	}
+	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req2.Header.Set("Accept", "application/json")
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		return
+	}
+	defer resp2.Body.Close()
+	body2, _ := io.ReadAll(io.LimitReader(resp2.Body, 1<<16))
+	fmt.Fprintf(os.Stderr, "diagnose (no deviceName): HTTP %d body=%s\n", resp2.StatusCode, truncate(string(body2), 300))
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/app/spike/bwapi/main.go
+++ b/app/spike/bwapi/main.go
@@ -307,18 +307,26 @@ func runScenarioB(ctx context.Context) error {
 	tokenURL := strings.TrimRight(identityBase, "/") + "/connect/token"
 	fmt.Printf("SDK gap: bitwarden-go-sdk v0.4.0 has no Personal API Key / client_credentials login.\n")
 	fmt.Printf("Probing raw HTTP POST %s\n", tokenURL)
+	fmt.Printf("Device metadata: deviceName=%s deviceType=%s deviceIdentifier=%s\n",
+		spikeDeviceName, spikeDeviceType, spikeDeviceIdentifier)
 
+	// Vaultwarden requires device_* on client_credentials (same as password grant).
+	// Form names match Bitwarden CLI / Scenario A (camelCase; VW also accepts snake_case).
 	form := url.Values{}
 	form.Set("grant_type", "client_credentials")
 	form.Set("client_id", clientID)
 	form.Set("client_secret", clientSecret)
 	form.Set("scope", "api")
+	form.Set("deviceIdentifier", spikeDeviceIdentifier)
+	form.Set("deviceName", spikeDeviceName)
+	form.Set("deviceType", spikeDeviceType)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/app/spike/bwapi/run.sh
+++ b/app/spike/bwapi/run.sh
@@ -36,8 +36,17 @@ if [[ -n "${GOENV_VER}" ]]; then
   echo "run.sh: GOENV_VERSION=${GOENV_VERSION} GOTOOLCHAIN=${GOTOOLCHAIN}" >&2
 fi
 
+# With no args: run this package.
+# Known go subcommands (build, mod, …) pass through: ./run.sh build -o /tmp/bwapi .
+# Anything else is forwarded as program args: ./run.sh apikey → go run . apikey
 if [[ $# -eq 0 ]]; then
   set -- run .
+elif [[ "$1" != "run" && "$1" != "build" && "$1" != "mod" && "$1" != "test" &&
+        "$1" != "env" && "$1" != "version" && "$1" != "get" && "$1" != "install" &&
+        "$1" != "list" && "$1" != "fmt" && "$1" != "vet" && "$1" != "generate" &&
+        "$1" != "clean" && "$1" != "work" && "$1" != "tool" && "$1" != "doc" &&
+        "$1" != "fix" ]]; then
+  set -- run . "$@"
 fi
 
 exec go "$@"

--- a/app/spike/bwapi/run.sh
+++ b/app/spike/bwapi/run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Bypass goenv's go.mod "go 1.26" check when 1.26 is not installed locally.
+# Uses an installed goenv version + GOTOOLCHAIN=auto so the Go toolchain
+# downloads 1.26 as needed.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+pick_goenv_version() {
+  if [[ -n "${GOENV_VERSION:-}" ]]; then
+    echo "$GOENV_VERSION"
+    return
+  fi
+  if ! command -v goenv >/dev/null 2>&1; then
+    return
+  fi
+  # Prefer newest installed 1.25.x, else any installed version (skip system).
+  local versions
+  versions="$(goenv versions --bare 2>/dev/null || true)"
+  if [[ -z "$versions" ]]; then
+    return
+  fi
+  local v
+  v="$(echo "$versions" | grep -E '^1\.25\.' | sort -V | tail -1 || true)"
+  if [[ -z "$v" ]]; then
+    v="$(echo "$versions" | grep -v '^system$' | sort -V | tail -1 || true)"
+  fi
+  echo "$v"
+}
+
+GOENV_VER="$(pick_goenv_version || true)"
+export GOTOOLCHAIN="${GOTOOLCHAIN:-auto}"
+
+if [[ -n "${GOENV_VER}" ]]; then
+  export GOENV_VERSION="$GOENV_VER"
+  echo "run.sh: GOENV_VERSION=${GOENV_VERSION} GOTOOLCHAIN=${GOTOOLCHAIN}" >&2
+fi
+
+if [[ $# -eq 0 ]]; then
+  set -- run .
+fi
+
+exec go "$@"

--- a/app/src/cmd/backend.go
+++ b/app/src/cmd/backend.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"bwsf/src/config"
+	"bwsf/src/utils"
+
+	"github.com/spf13/cobra"
+)
+
+var backendSet string
+
+var backendCmd = &cobra.Command{
+	Use:   "backend",
+	Short: "Show or set the Bitwarden backend",
+	Long:  "Show the current Bitwarden backend (bw or api), or update it with --set",
+	Run:   runBackend,
+}
+
+func init() {
+	backendCmd.Flags().StringVar(&backendSet, "set", "", "Set backend to \"bw\" or \"api\"")
+	rootCmd.AddCommand(backendCmd)
+}
+
+func runBackend(cmd *cobra.Command, args []string) {
+	if backendSet != "" {
+		if err := setBackend(backendSet); err != nil {
+			utils.Errorln("[ERROR]", err)
+			os.Exit(1)
+		}
+		utils.Successln("[INFO] ✅ Backend set to " + backendSet)
+		return
+	}
+
+	backend, err := currentBackend()
+	if err != nil {
+		utils.Errorln("[ERROR]", err)
+		os.Exit(1)
+	}
+	fmt.Println(backend)
+}
+
+func currentBackend() (string, error) {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to load config: %w", err)
+	}
+	return cfg.GetBackend(), nil
+}
+
+func setBackend(value string) error {
+	if !config.IsValidBackend(value) {
+		return fmt.Errorf("invalid backend %q: use %q or %q", value, config.BackendBW, config.BackendAPI)
+	}
+
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+
+	cfg.Backend = value
+	if err := config.SaveConfig(cfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+	return nil
+}

--- a/app/src/cmd/client.go
+++ b/app/src/cmd/client.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"os"
+
+	"bwsf/src/config"
+	"bwsf/src/core"
+	"bwsf/src/infra"
+	"bwsf/src/utils"
+)
+
+// loadConfigOrEmpty loads ~/.config/bwsf/config.json, or returns an empty config when missing.
+func loadConfigOrEmpty() *config.Config {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		utils.Errorln("[ERROR] Failed to load config:", err)
+		os.Exit(1)
+	}
+	if cfg == nil {
+		return &config.Config{}
+	}
+	return cfg
+}
+
+// newBwClientFromConfig builds the BwClient for cfg and exits on factory errors.
+func newBwClientFromConfig(cfg *config.Config) core.BwClient {
+	bw, err := infra.NewBwClientFromConfig(cfg)
+	if err != nil {
+		utils.Errorln("[ERROR]", err)
+		os.Exit(1)
+	}
+	return bw
+}
+
+// requireBwCLIIfNeeded exits when the bw CLI is required but not installed.
+func requireBwCLIIfNeeded(cfg *config.Config) {
+	if cfg.GetBackend() != config.BackendBW {
+		return
+	}
+	installed, _ := utils.CheckBwCommand()
+	if !installed {
+		utils.Errorln("[ERROR] ❌ bw command is not installed...")
+		os.Exit(1)
+	}
+}

--- a/app/src/cmd/cmd_test.go
+++ b/app/src/cmd/cmd_test.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"os"
 	"testing"
+
+	"bwsf/src/config"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -90,6 +93,21 @@ func TestSetupCmd_Registered(t *testing.T) {
 	assert.True(t, found, "setup command should be registered")
 }
 
+// 正常系: backend コマンドが登録されている
+func TestBackendCmd_Registered(t *testing.T) {
+	assert.NotNil(t, backendCmd)
+	assert.Equal(t, "backend", backendCmd.Use)
+
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "backend" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "backend command should be registered")
+}
+
 // =============================================================================
 // フラグのテスト
 // =============================================================================
@@ -106,6 +124,13 @@ func TestPullCmd_OutputFlag(t *testing.T) {
 	flag := pullCmd.Flags().Lookup("output")
 	assert.NotNil(t, flag)
 	assert.Equal(t, ".", flag.DefValue)
+}
+
+// 正常系: backend コマンドに --set フラグがある
+func TestBackendCmd_SetFlag(t *testing.T) {
+	flag := backendCmd.Flags().Lookup("set")
+	assert.NotNil(t, flag)
+	assert.Equal(t, "", flag.DefValue)
 }
 
 // =============================================================================
@@ -134,6 +159,78 @@ func TestListCmd_Description(t *testing.T) {
 func TestSetupCmd_Description(t *testing.T) {
 	assert.NotEmpty(t, setupCmd.Short)
 	assert.NotEmpty(t, setupCmd.Long)
+}
+
+// 正常系: backend コマンドに説明がある
+func TestBackendCmd_Description(t *testing.T) {
+	assert.NotEmpty(t, backendCmd.Short)
+	assert.NotEmpty(t, backendCmd.Long)
+}
+
+// =============================================================================
+// backend コマンドのロジックテスト
+// =============================================================================
+
+// 正常系: 設定なしでは currentBackend が bw を返す
+func TestCurrentBackend_DefaultBW(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	backend, err := currentBackend()
+	assert.NoError(t, err)
+	assert.Equal(t, config.BackendBW, backend)
+}
+
+// 正常系: setBackend で api に更新できる
+func TestSetBackend_API(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	err := setBackend(config.BackendAPI)
+	assert.NoError(t, err)
+
+	backend, err := currentBackend()
+	assert.NoError(t, err)
+	assert.Equal(t, config.BackendAPI, backend)
+
+	cfg, err := config.LoadConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, config.BackendAPI, cfg.Backend)
+}
+
+// 正常系: setBackend で既存設定を保ったまま backend だけ更新
+func TestSetBackend_PreservesOtherFields(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	err := config.SaveConfig(&config.Config{
+		HostType: "cloud",
+		Email:    "user@example.com",
+		Backend:  config.BackendBW,
+	})
+	assert.NoError(t, err)
+
+	err = setBackend(config.BackendAPI)
+	assert.NoError(t, err)
+
+	cfg, err := config.LoadConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, "cloud", cfg.HostType)
+	assert.Equal(t, "user@example.com", cfg.Email)
+	assert.Equal(t, config.BackendAPI, cfg.Backend)
+}
+
+// 異常系: 不正な backend 値はエラー
+func TestSetBackend_Invalid(t *testing.T) {
+	err := setBackend("cli")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid backend")
 }
 
 

--- a/app/src/cmd/list.go
+++ b/app/src/cmd/list.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bwsf/src/config"
 	"bwsf/src/core"
 	"bwsf/src/infra"
 	"bwsf/src/utils"
@@ -23,25 +22,11 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) {
-	// Check if bw command is installed
-	installed, _ := utils.CheckBwCommand()
-	if !installed {
-		utils.Errorln("[ERROR] ❌ bw command is not installed...")
-		os.Exit(1)
-	}
-
-	// Load config
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		utils.Errorln("[ERROR] Failed to load config:", err)
-		os.Exit(1)
-	}
-	if cfg == nil {
-		cfg = &config.Config{}
-	}
+	cfg := loadConfigOrEmpty()
+	requireBwCLIIfNeeded(cfg)
 
 	// Create dependencies
-	bw := infra.NewBwClient()
+	bw := newBwClientFromConfig(cfg)
 	logger := infra.NewLogger()
 
 	// Call core logic

--- a/app/src/cmd/pull.go
+++ b/app/src/cmd/pull.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bwsf/src/config"
 	"bwsf/src/core"
 	"bwsf/src/infra"
 	"bwsf/src/utils"
@@ -25,12 +24,8 @@ func init() {
 }
 
 func runPull(cmd *cobra.Command, args []string) {
-	// Check if bw command is installed
-	installed, _ := utils.CheckBwCommand()
-	if !installed {
-		utils.Errorln("[ERROR] ❌ bw command is not installed...")
-		os.Exit(1)
-	}
+	cfg := loadConfigOrEmpty()
+	requireBwCLIIfNeeded(cfg)
 
 	// Get --output flag value
 	outputDir, err := cmd.Flags().GetString("output")
@@ -47,18 +42,8 @@ func runPull(cmd *cobra.Command, args []string) {
 	}
 	projectName := filepath.Base(wd)
 
-	// Load config
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		utils.Errorln("[ERROR] Failed to load config:", err)
-		os.Exit(1)
-	}
-	if cfg == nil {
-		cfg = &config.Config{}
-	}
-
 	// Create dependencies
-	bw := infra.NewBwClient()
+	bw := newBwClientFromConfig(cfg)
 	fs := infra.NewFileSystem()
 	logger := infra.NewLogger()
 

--- a/app/src/cmd/push.go
+++ b/app/src/cmd/push.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bwsf/src/config"
 	"bwsf/src/core"
 	"bwsf/src/infra"
 	"bwsf/src/utils"
@@ -24,12 +23,8 @@ func init() {
 }
 
 func runPush(cmd *cobra.Command, args []string) {
-	// Check if bw command is installed
-	installed, _ := utils.CheckBwCommand()
-	if !installed {
-		utils.Errorln("[ERROR] ❌ bw command is not installed...")
-		os.Exit(1)
-	}
+	cfg := loadConfigOrEmpty()
+	requireBwCLIIfNeeded(cfg)
 
 	// Get --from flag value
 	fromDir, err := cmd.Flags().GetString("from")
@@ -46,18 +41,8 @@ func runPush(cmd *cobra.Command, args []string) {
 	}
 	projectName := filepath.Base(wd)
 
-	// Load config
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		utils.Errorln("[ERROR] Failed to load config:", err)
-		os.Exit(1)
-	}
-	if cfg == nil {
-		cfg = &config.Config{}
-	}
-
 	// Create dependencies
-	bw := infra.NewBwClient()
+	bw := newBwClientFromConfig(cfg)
 	fs := infra.NewFileSystem()
 	logger := infra.NewLogger()
 

--- a/app/src/cmd/setup.go
+++ b/app/src/cmd/setup.go
@@ -21,15 +21,11 @@ func init() {
 }
 
 func runSetup(cmd *cobra.Command, args []string) {
-	// Check if bw command is installed
-	installed, _ := utils.CheckBwCommand()
-	if !installed {
-		utils.Errorln("[ERROR] ❌ bw command is not installed...")
-		os.Exit(1)
-	}
+	cfg := loadConfigOrEmpty()
+	requireBwCLIIfNeeded(cfg)
 
 	// Create dependencies
-	bw := infra.NewBwClient()
+	bw := newBwClientFromConfig(cfg)
 	fs := infra.NewFileSystem()
 	logger := infra.NewLogger()
 

--- a/app/src/config/config.go
+++ b/app/src/config/config.go
@@ -11,12 +11,31 @@ type Config struct {
 	HostType      string `json:"host_type"`      // "cloud" or "selfhosted"
 	SelfhostedURL string `json:"selfhosted_url"` // URL for self-hosted instance
 	Email         string `json:"email"`          // Email address
+	Backend       string `json:"backend,omitempty"` // "bw" (CLI) or "api"; default "bw" when unset
 }
 
 const (
 	configDir  = ".config/bwsf"
 	configFile = "config.json"
+
+	// BackendBW uses the Bitwarden CLI (`bw`) adapter.
+	BackendBW = "bw"
+	// BackendAPI uses the Bitwarden API adapter (not fully implemented yet).
+	BackendAPI = "api"
 )
+
+// GetBackend returns the configured backend, defaulting to "bw" when unset (backward compatible).
+func (c *Config) GetBackend() string {
+	if c == nil || c.Backend == "" {
+		return BackendBW
+	}
+	return c.Backend
+}
+
+// IsValidBackend reports whether backend is a supported value ("bw" or "api").
+func IsValidBackend(backend string) bool {
+	return backend == BackendBW || backend == BackendAPI
+}
 
 // GetConfigPath returns the full path to the config file
 func GetConfigPath() (string, error) {

--- a/app/src/config/config_test.go
+++ b/app/src/config/config_test.go
@@ -63,6 +63,8 @@ func TestLoadConfig_Success(t *testing.T) {
 	assert.Equal(t, "selfhosted", cfg.HostType)
 	assert.Equal(t, "https://bw.example.com", cfg.SelfhostedURL)
 	assert.Equal(t, "test@example.com", cfg.Email)
+	assert.Equal(t, "", cfg.Backend)
+	assert.Equal(t, BackendBW, cfg.GetBackend())
 }
 
 // 異常系: JSON が壊れている場合はエラー
@@ -169,6 +171,73 @@ func TestSaveConfig_Overwrite(t *testing.T) {
 	assert.Equal(t, "selfhosted", loaded.HostType)
 	assert.Equal(t, "https://new.example.com", loaded.SelfhostedURL)
 	assert.Equal(t, "new@example.com", loaded.Email)
+}
+
+// =============================================================================
+// Backend フィールドのテスト
+// =============================================================================
+
+// 正常系: backend 未設定時は GetBackend が "bw" を返す
+func TestGetBackend_DefaultBW(t *testing.T) {
+	assert.Equal(t, BackendBW, (*Config)(nil).GetBackend())
+	assert.Equal(t, BackendBW, (&Config{}).GetBackend())
+	assert.Equal(t, BackendBW, (&Config{Backend: ""}).GetBackend())
+}
+
+// 正常系: backend が明示されている場合はその値を返す
+func TestGetBackend_Explicit(t *testing.T) {
+	assert.Equal(t, BackendAPI, (&Config{Backend: BackendAPI}).GetBackend())
+	assert.Equal(t, BackendBW, (&Config{Backend: BackendBW}).GetBackend())
+}
+
+// 正常系: IsValidBackend が bw / api のみ true
+func TestIsValidBackend(t *testing.T) {
+	assert.True(t, IsValidBackend(BackendBW))
+	assert.True(t, IsValidBackend(BackendAPI))
+	assert.False(t, IsValidBackend(""))
+	assert.False(t, IsValidBackend("cli"))
+}
+
+// 正常系: backend 付き config の読み書き
+func TestLoadSaveConfig_WithBackend(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	cfg := &Config{
+		HostType: "cloud",
+		Email:    "user@example.com",
+		Backend:  BackendAPI,
+	}
+	err := SaveConfig(cfg)
+	assert.NoError(t, err)
+
+	loaded, err := LoadConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, BackendAPI, loaded.Backend)
+	assert.Equal(t, BackendAPI, loaded.GetBackend())
+
+	content, _ := os.ReadFile(filepath.Join(tmpDir, ".config", "bwsf", "config.json"))
+	assert.Contains(t, string(content), `"backend": "api"`)
+}
+
+// 正常系: backend 未指定の JSON でも読み込め、デフォルトは bw
+func TestLoadConfig_BackendOmitted(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	configDir := filepath.Join(tmpDir, ".config", "bwsf")
+	os.MkdirAll(configDir, 0755)
+	configPath := filepath.Join(configDir, "config.json")
+	os.WriteFile(configPath, []byte(`{"host_type":"cloud","email":"a@b.com"}`), 0600)
+
+	cfg, err := LoadConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, "", cfg.Backend)
+	assert.Equal(t, BackendBW, cfg.GetBackend())
 }
 
 

--- a/app/src/core/core.go
+++ b/app/src/core/core.go
@@ -547,11 +547,14 @@ func SetupBitwardenCore(
 		return fmt.Errorf("failed to login: %w", err)
 	}
 
-	// 設定を保存
+	// 設定を保存（既存の backend 設定は維持）
 	newConfig := &config.Config{
 		HostType:      hostType,
 		SelfhostedURL: selfhostedURL,
 		Email:         email,
+	}
+	if existingConfig != nil {
+		newConfig.Backend = existingConfig.Backend
 	}
 	if err := config.SaveConfig(newConfig); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)

--- a/app/src/infra/apiclient.go
+++ b/app/src/infra/apiclient.go
@@ -1,0 +1,63 @@
+package infra
+
+import (
+	"errors"
+
+	"bwsf/src/core"
+)
+
+// ErrAPINotImplemented is returned by the API backend stub until later Issue #53 steps land.
+var ErrAPINotImplemented = errors.New(
+	"API backend is not implemented yet (Issue #53). " +
+		"The Step 0 feasibility spike lives under app/spike/. " +
+		"Use `bwsf backend --set bw` to switch back to the Bitwarden CLI backend",
+)
+
+// ApiBwClient is a stub BwClient for backend "api".
+// All methods return ErrAPINotImplemented until the real API adapter is wired.
+type ApiBwClient struct{}
+
+// NewApiBwClient creates an ApiBwClient stub.
+func NewApiBwClient() *ApiBwClient {
+	return &ApiBwClient{}
+}
+
+func (c *ApiBwClient) GetDotenvsFolderID() (string, error) {
+	return "", ErrAPINotImplemented
+}
+
+func (c *ApiBwClient) DotenvsFolderExists() (bool, error) {
+	return false, ErrAPINotImplemented
+}
+
+func (c *ApiBwClient) CreateDotenvsFolder() error {
+	return ErrAPINotImplemented
+}
+
+func (c *ApiBwClient) ListItemsInFolder(folderID string) ([]core.Item, error) {
+	return nil, ErrAPINotImplemented
+}
+
+func (c *ApiBwClient) GetItemByName(folderID, name string) (*core.FullItem, error) {
+	return nil, ErrAPINotImplemented
+}
+
+func (c *ApiBwClient) GetItemByID(id string) (*core.FullItem, error) {
+	return nil, ErrAPINotImplemented
+}
+
+func (c *ApiBwClient) CreateNoteItem(folderID, name, notes string) error {
+	return ErrAPINotImplemented
+}
+
+func (c *ApiBwClient) UpdateNoteItem(id, notes string) error {
+	return ErrAPINotImplemented
+}
+
+func (c *ApiBwClient) Login(email, password, serverURL string) error {
+	return ErrAPINotImplemented
+}
+
+func (c *ApiBwClient) Unlock(masterPassword string) error {
+	return ErrAPINotImplemented
+}

--- a/app/src/infra/factory.go
+++ b/app/src/infra/factory.go
@@ -1,0 +1,26 @@
+package infra
+
+import (
+	"fmt"
+
+	"bwsf/src/config"
+	"bwsf/src/core"
+)
+
+// NewBwClientFromConfig selects a BwClient implementation based on cfg.Backend.
+// When cfg is nil or Backend is unset, the Bitwarden CLI (`bw`) adapter is used.
+func NewBwClientFromConfig(cfg *config.Config) (core.BwClient, error) {
+	backend := config.BackendBW
+	if cfg != nil {
+		backend = cfg.GetBackend()
+	}
+
+	switch backend {
+	case config.BackendBW:
+		return NewBwClient(), nil
+	case config.BackendAPI:
+		return NewApiBwClient(), nil
+	default:
+		return nil, fmt.Errorf("unsupported backend %q: use %q or %q", backend, config.BackendBW, config.BackendAPI)
+	}
+}

--- a/app/src/infra/infra_test.go
+++ b/app/src/infra/infra_test.go
@@ -3,6 +3,9 @@ package infra
 import (
 	"testing"
 
+	"bwsf/src/config"
+	"bwsf/src/core"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -93,6 +96,76 @@ func TestUnlockError_ImplementsError(t *testing.T) {
 
 	assert.Equal(t, "unlock failed", err.Error())
 }
+
+// =============================================================================
+// NewBwClientFromConfig / ApiBwClient のテスト
+// =============================================================================
+
+// 正常系: nil / 未設定 config では CLI (bw) アダプタが選ばれる
+func TestNewBwClientFromConfig_DefaultBW(t *testing.T) {
+	client, err := NewBwClientFromConfig(nil)
+	assert.NoError(t, err)
+	assert.IsType(t, &RealBwClient{}, client)
+
+	client, err = NewBwClientFromConfig(&config.Config{})
+	assert.NoError(t, err)
+	assert.IsType(t, &RealBwClient{}, client)
+
+	client, err = NewBwClientFromConfig(&config.Config{Backend: config.BackendBW})
+	assert.NoError(t, err)
+	assert.IsType(t, &RealBwClient{}, client)
+}
+
+// 正常系: backend=api では stub アダプタが選ばれる
+func TestNewBwClientFromConfig_API(t *testing.T) {
+	client, err := NewBwClientFromConfig(&config.Config{Backend: config.BackendAPI})
+	assert.NoError(t, err)
+	assert.IsType(t, &ApiBwClient{}, client)
+}
+
+// 異常系: 不明な backend はエラー
+func TestNewBwClientFromConfig_Unsupported(t *testing.T) {
+	client, err := NewBwClientFromConfig(&config.Config{Backend: "unknown"})
+	assert.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "unsupported backend")
+}
+
+// 正常系: ApiBwClient の各メソッドは not implemented エラーを返す
+func TestApiBwClient_NotImplemented(t *testing.T) {
+	client := NewApiBwClient()
+
+	_, err := client.GetDotenvsFolderID()
+	assert.ErrorIs(t, err, ErrAPINotImplemented)
+
+	_, err = client.DotenvsFolderExists()
+	assert.ErrorIs(t, err, ErrAPINotImplemented)
+
+	assert.ErrorIs(t, client.CreateDotenvsFolder(), ErrAPINotImplemented)
+
+	_, err = client.ListItemsInFolder("id")
+	assert.ErrorIs(t, err, ErrAPINotImplemented)
+
+	_, err = client.GetItemByName("id", "name")
+	assert.ErrorIs(t, err, ErrAPINotImplemented)
+
+	_, err = client.GetItemByID("id")
+	assert.ErrorIs(t, err, ErrAPINotImplemented)
+
+	assert.ErrorIs(t, client.CreateNoteItem("id", "n", "notes"), ErrAPINotImplemented)
+	assert.ErrorIs(t, client.UpdateNoteItem("id", "notes"), ErrAPINotImplemented)
+	assert.ErrorIs(t, client.Login("e", "p", ""), ErrAPINotImplemented)
+	assert.ErrorIs(t, client.Unlock("p"), ErrAPINotImplemented)
+
+	assert.Contains(t, ErrAPINotImplemented.Error(), "Issue #53")
+	assert.Contains(t, ErrAPINotImplemented.Error(), "bwsf backend --set bw")
+}
+
+// 正常系: ApiBwClient が BwClient インターフェースを実装している
+func TestApiBwClient_ImplementsInterface(t *testing.T) {
+	var _ core.BwClient = NewApiBwClient()
+}
+
 
 // =============================================================================
 // realFileInfo のテスト


### PR DESCRIPTION
## Summary
- Add `backend` config (`bw` | `api`, default `bw`) and `bwsf backend` / `bwsf backend --set` command
- Introduce factory selection for BwClient adapters and keep existing CLI users on the `bw` path
- Add an `api` stub that returns a clear not-implemented error until later Issue #53 steps

## Test plan
- [ ] `make test-unit` passes
- [ ] `bwsf backend` prints `bw` by default
- [ ] `bwsf backend --set api` then `bwsf backend` prints `api`
- [ ] `bwsf backend --set bw` switches back
- [ ] With `backend=api`, vault commands fail with a clear not-implemented message
- [ ] With `backend=bw`, existing setup/push/pull/list behavior is unchanged


Made with [Cursor](https://cursor.com)