### PR TITLE
ci(docs): main に docs が載ったら Pages を CD

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,13 @@
 name: Deploy Docs
 
 on:
-  pull_request:
-    types: [closed]
+  # docs → main マージ（および docs/site の main 反映）で CD
+  push:
     branches:
       - main
+    paths:
+      - 'docs/site/**'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -21,9 +24,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'docs')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,4 +63,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-


### PR DESCRIPTION
## Summary
- Deploy Docs を `pull_request` (docs → main マージ時) から、`main` への `push`（`docs/site/**` 変更時）に変更
- 旧トリガーは build 成功後、`github-pages` 環境の deploy が即失敗していました（deployment ref 問題）
- `workflow_dispatch` は従来どおり手動実行可能

## Behavior
- `docs` を `main` にマージ → `docs/site` が変わる → この workflow が走って Pages へデプロイ
- 今回の docs 内容は手動 `workflow_dispatch` で既に本番反映済み（https://b4m-oss.github.io/bwsf/）

## Test plan
- [ ] この PR を main にマージ（workflow ファイル変更なので自身がトリガーされる）
- [ ] Deploy Docs が success になること