### PR TITLE
feat: add bwsf clean command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Simple usage below:
 | bwsf push | .env files push to your Bitwarden host |
 | bwsf pull | .env files pull from your Bitwarden host |
 | bwsf list | Show list stored .env files at your Bitwarden host |
+| bwsf clean | Remove local .env files after verifying Bitwarden backup |
 
 ## Motivation
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -50,6 +50,7 @@ bwsfコマンドは、Bitwardenで管理されているdotenvファイルをサ�
 | bwsf push | .envファイルをBitwardenホストにプッシュ |
 | bwsf pull | Bitwardenホストから.envファイルをプル |
 | bwsf list | Bitwardenホストに保存されている.envファイルの一覧を表示 |
+| bwsf clean | リモートバックアップを確認したうえでローカルの.envファイルを削除 |
 
 ## 動機
 

--- a/app/src/cmd/clean.go
+++ b/app/src/cmd/clean.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"bwsf/src/config"
+	"bwsf/src/core"
+	"bwsf/src/infra"
+	"bwsf/src/utils"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var cleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Remove local .env files after verifying Bitwarden backup",
+	Long:  "Remove bwsf-managed local .env* files after confirming the remote Bitwarden note item has matching (or explicitly handled) contents",
+	Run:   runClean,
+}
+
+func init() {
+	cleanCmd.Flags().String("from", ".", "Directory containing .env files to clean")
+	rootCmd.AddCommand(cleanCmd)
+}
+
+func runClean(cmd *cobra.Command, args []string) {
+	installed, _ := utils.CheckBwCommand()
+	if !installed {
+		utils.Errorln("[ERROR] ❌ bw command is not installed...")
+		os.Exit(1)
+	}
+
+	fromDir, err := cmd.Flags().GetString("from")
+	if err != nil {
+		utils.Errorln("[ERROR] Failed to get --from flag:", err)
+		os.Exit(1)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		utils.Errorln("[ERROR] Failed to get current working directory:", err)
+		os.Exit(1)
+	}
+	projectName := filepath.Base(wd)
+
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		utils.Errorln("[ERROR] Failed to load config:", err)
+		os.Exit(1)
+	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+
+	bw := infra.NewBwClient()
+	fs := infra.NewFileSystem()
+	logger := infra.NewLogger()
+
+	envFiles, err := core.GetPushedEnvFiles(fromDir, fs)
+	if err != nil {
+		utils.Errorln("[ERROR] Failed to find .env files:", err)
+		os.Exit(1)
+	}
+	if len(envFiles) == 0 {
+		utils.Errorln("[ERROR] No .env files found")
+		os.Exit(1)
+	}
+
+	utils.Infoln("[INFO] Found", len(envFiles), "env file(s) to clean:")
+	for _, f := range envFiles {
+		utils.Infoln("  -", f)
+	}
+
+	selectMismatchAction := func(mismatchedFiles []string) (core.CleanMismatchAction, error) {
+		choice, selectErr := utils.SelectCleanMismatchAction(mismatchedFiles)
+		if selectErr != nil {
+			return core.CleanActionAbort, selectErr
+		}
+		switch choice {
+		case utils.CleanMismatchOverwriteRemoteThenClean:
+			return core.CleanActionOverwriteRemoteThenClean, nil
+		case utils.CleanMismatchRemoveLocal:
+			return core.CleanActionRemoveLocal, nil
+		default:
+			return core.CleanActionAbort, nil
+		}
+	}
+
+	err = core.CleanEnvCore(
+		fromDir,
+		projectName,
+		fs,
+		bw,
+		cfg,
+		utils.InputPassword,
+		selectMismatchAction,
+		logger,
+	)
+	if err != nil {
+		if errors.Is(err, core.ErrCleanAborted) {
+			utils.Infoln("[INFO] Clean aborted. Local files were kept.")
+			return
+		}
+		utils.Errorln("[ERROR]", err)
+		os.Exit(1)
+	}
+
+	utils.Successln("[INFO] ✅", len(envFiles), "env file(s) cleaned successfully!")
+}

--- a/app/src/cmd/cmd_test.go
+++ b/app/src/cmd/cmd_test.go
@@ -90,6 +90,21 @@ func TestSetupCmd_Registered(t *testing.T) {
 	assert.True(t, found, "setup command should be registered")
 }
 
+// 正常系: clean コマンドが登録されている
+func TestCleanCmd_Registered(t *testing.T) {
+	assert.NotNil(t, cleanCmd)
+	assert.Equal(t, "clean", cleanCmd.Use)
+
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "clean" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "clean command should be registered")
+}
+
 // =============================================================================
 // フラグのテスト
 // =============================================================================
@@ -104,6 +119,13 @@ func TestPushCmd_FromFlag(t *testing.T) {
 // 正常系: pull コマンドに --output フラグがある
 func TestPullCmd_OutputFlag(t *testing.T) {
 	flag := pullCmd.Flags().Lookup("output")
+	assert.NotNil(t, flag)
+	assert.Equal(t, ".", flag.DefValue)
+}
+
+// 正常系: clean コマンドに --from フラグがある
+func TestCleanCmd_FromFlag(t *testing.T) {
+	flag := cleanCmd.Flags().Lookup("from")
 	assert.NotNil(t, flag)
 	assert.Equal(t, ".", flag.DefValue)
 }
@@ -136,5 +158,8 @@ func TestSetupCmd_Description(t *testing.T) {
 	assert.NotEmpty(t, setupCmd.Long)
 }
 
-
-
+// 正常系: clean コマンドに説明がある
+func TestCleanCmd_Description(t *testing.T) {
+	assert.NotEmpty(t, cleanCmd.Short)
+	assert.NotEmpty(t, cleanCmd.Long)
+}

--- a/app/src/core/core.go
+++ b/app/src/core/core.go
@@ -2,12 +2,17 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"bwsf/src/config"
 )
+
+// ErrCleanAborted は差分あり時にユーザーが Abort を選んだことを表します。
+var ErrCleanAborted = errors.New("clean aborted by user")
 
 // BwClient は Bitwarden CLI とのやり取りを抽象化するインターフェースです。
 type BwClient interface {
@@ -28,10 +33,23 @@ type FileSystem interface {
 	OpenEnvFile(path string) ([]byte, error)
 	ReadFile(path string) ([]byte, error)
 	WriteFile(path string, data []byte, perm uint32) error
+	Remove(path string) error
 	Stat(path string) (FileInfo, error)
 	MkdirAll(path string, perm uint32) error
 	ReadDir(path string) ([]DirEntry, error)
 }
+
+// CleanMismatchAction はローカル/リモート差分時のユーザー選択です。
+type CleanMismatchAction int
+
+const (
+	// CleanActionAbort は削除を中止します（安全側の既定）。
+	CleanActionAbort CleanMismatchAction = iota
+	// CleanActionOverwriteRemoteThenClean はリモートをローカルで上書きしてからローカルを削除します。
+	CleanActionOverwriteRemoteThenClean
+	// CleanActionRemoveLocal はリモートを更新せずローカルのみ削除します（危険）。
+	CleanActionRemoveLocal
+)
 
 // DirEntry はディレクトリエントリを表します。
 type DirEntry interface {
@@ -389,6 +407,125 @@ func PullEnvCore(
 	}
 
 	return nil
+}
+
+// CleanEnvCore は bwsf 管理対象のローカル .env* を、リモートバックアップを確認したうえで削除します。
+func CleanEnvCore(
+	targetDir, projectName string,
+	fs FileSystem,
+	bw BwClient,
+	cfg *config.Config,
+	promptPassword func() (string, error),
+	selectMismatchAction func(mismatchedFiles []string) (CleanMismatchAction, error),
+	logger Logger,
+) error {
+	envFiles, err := findEnvFilesFromFS(fs, targetDir)
+	if err != nil {
+		return fmt.Errorf("failed to find .env files: %w", err)
+	}
+	if len(envFiles) == 0 {
+		return fmt.Errorf("no .env files found in %s", targetDir)
+	}
+
+	localData := make(MultiEnvData)
+	for _, envPath := range envFiles {
+		content, readErr := fs.ReadFile(envPath)
+		if readErr != nil {
+			return fmt.Errorf("failed to read %s: %w", envPath, readErr)
+		}
+		localData[filepath.Base(envPath)] = *parseEnvContent(content)
+	}
+
+	var folderID string
+	err = WithUnlockRetry(bw, cfg, promptPassword, logger, func() error {
+		var innerErr error
+		folderID, innerErr = bw.GetDotenvsFolderID()
+		return innerErr
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get dotenvs folder: %w", err)
+	}
+
+	var item *FullItem
+	err = WithUnlockRetry(bw, cfg, promptPassword, logger, func() error {
+		var innerErr error
+		item, innerErr = bw.GetItemByName(folderID, projectName)
+		return innerErr
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get item: %w", err)
+	}
+	if item == nil {
+		return fmt.Errorf("item '%s' not found in dotenvs folder; aborting clean", projectName)
+	}
+
+	remoteData, err := restoreMultiEnvFromJSON(item.Notes)
+	if err != nil {
+		envContent, legacyErr := restoreEnvFileFromJSON(item.Notes)
+		if legacyErr != nil {
+			return fmt.Errorf("failed to restore remote env data: %w", err)
+		}
+		remoteData = MultiEnvData{
+			".env": EnvData{Lines: strings.Split(envContent, "\n")},
+		}
+	}
+	if len(remoteData) == 0 {
+		return fmt.Errorf("item '%s' has no env files on remote; aborting clean", projectName)
+	}
+
+	mismatched := diffMultiEnvData(localData, remoteData)
+	if len(mismatched) == 0 {
+		return removeLocalEnvFiles(fs, envFiles)
+	}
+
+	action, err := selectMismatchAction(mismatched)
+	if err != nil {
+		return fmt.Errorf("failed to select clean action: %w", err)
+	}
+
+	switch action {
+	case CleanActionAbort:
+		return ErrCleanAborted
+	case CleanActionOverwriteRemoteThenClean:
+		if err := PushEnvCore(targetDir, projectName, fs, bw, cfg, promptPassword, logger); err != nil {
+			return fmt.Errorf("failed to overwrite remote before clean: %w", err)
+		}
+		return removeLocalEnvFiles(fs, envFiles)
+	case CleanActionRemoveLocal:
+		return removeLocalEnvFiles(fs, envFiles)
+	default:
+		return fmt.Errorf("unknown clean action: %v", action)
+	}
+}
+
+func removeLocalEnvFiles(fs FileSystem, envFiles []string) error {
+	for _, envPath := range envFiles {
+		if err := fs.Remove(envPath); err != nil {
+			return fmt.Errorf("failed to remove %s: %w", envPath, err)
+		}
+	}
+	return nil
+}
+
+func diffMultiEnvData(local, remote MultiEnvData) []string {
+	keys := make(map[string]struct{})
+	for k := range local {
+		keys[k] = struct{}{}
+	}
+	for k := range remote {
+		keys[k] = struct{}{}
+	}
+
+	var mismatched []string
+	for k := range keys {
+		l, lok := local[k]
+		r, rok := remote[k]
+		if !lok || !rok || !reflect.DeepEqual(l.Lines, r.Lines) {
+			mismatched = append(mismatched, k)
+		}
+	}
+	sortFileNames(mismatched)
+	return mismatched
 }
 
 // GetPulledEnvFiles は pull 対象の .env ファイル名一覧を返します（表示用）

--- a/app/src/core/core_test.go
+++ b/app/src/core/core_test.go
@@ -154,6 +154,10 @@ type mockFileSystem struct {
 	writtenFiles map[string][]byte // 複数ファイル用
 	writeErr     error
 
+	// Remove の挙動制御
+	removedFiles []string
+	removeErr    error
+
 	// Stat の挙動制御
 	statInfo    FileInfo
 	statInfoMap map[string]FileInfo // ファイルパスごとの情報
@@ -197,6 +201,15 @@ func (m *mockFileSystem) WriteFile(path string, data []byte, perm uint32) error 
 	}
 	m.writtenFiles[path] = data
 	return m.writeErr
+}
+
+func (m *mockFileSystem) Remove(path string) error {
+	m.calls = append(m.calls, fmt.Sprintf("Remove(%s)", path))
+	m.removedFiles = append(m.removedFiles, path)
+	if m.readContentMap != nil {
+		delete(m.readContentMap, path)
+	}
+	return m.removeErr
 }
 
 func (m *mockFileSystem) Stat(path string) (FileInfo, error) {
@@ -1777,7 +1790,7 @@ func TestPushEnvCore_DoubleDotFromDir(t *testing.T) {
 // 正常系: MultiEnvData を JSON に変換して復元
 func TestMultiEnvData_RoundTrip(t *testing.T) {
 	original := MultiEnvData{
-		".env": EnvData{Lines: []string{"KEY1=value1", "KEY2=value2"}},
+		".env":         EnvData{Lines: []string{"KEY1=value1", "KEY2=value2"}},
 		".env.staging": EnvData{Lines: []string{"KEY1=staging1", "KEY2=staging2"}},
 	}
 
@@ -2085,6 +2098,276 @@ func TestGetPulledEnvFiles_LegacyFormat(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, files, 1)
 	assert.Equal(t, ".env", files[0])
+}
+
+// =============================================================================
+// CleanEnvCore のテスト
+// =============================================================================
+
+func multiEnvNotes(files map[string][]string) string {
+	data := make(MultiEnvData)
+	for name, lines := range files {
+		data[name] = EnvData{Lines: lines}
+	}
+	jsonStr, err := multiEnvDataToJSON(data)
+	if err != nil {
+		panic(err)
+	}
+	return jsonStr
+}
+
+// 正常系: 内容一致なら確認なしでローカル削除
+func TestCleanEnvCore_MatchRemovesLocal(t *testing.T) {
+	notes := multiEnvNotes(map[string][]string{".env": {"KEY=value"}})
+	bw := &mockBwClient{
+		folderID:   "folder-123",
+		itemByName: &FullItem{ID: "item-456", Name: "my-project", Notes: notes},
+	}
+	fs := &mockFileSystem{
+		dirEntries: []DirEntry{&mockDirEntry{name: ".env"}},
+		readContentMap: map[string][]byte{
+			".env": []byte("KEY=value"),
+		},
+	}
+	logger := &mockLogger{}
+	cfg := &config.Config{}
+	selectCalled := false
+
+	err := CleanEnvCore(
+		".",
+		"my-project",
+		fs,
+		bw,
+		cfg,
+		func() (string, error) { return "pwd", nil },
+		func(mismatched []string) (CleanMismatchAction, error) {
+			selectCalled = true
+			return CleanActionAbort, nil
+		},
+		logger,
+	)
+
+	assert.NoError(t, err)
+	assert.False(t, selectCalled)
+	assert.Contains(t, fs.calls, "Remove(.env)")
+	assert.NotContains(t, bw.calls, "UpdateNoteItem(item-456)")
+}
+
+// 正常系: 差分ありで overwrite then clean
+func TestCleanEnvCore_OverwriteRemoteThenClean(t *testing.T) {
+	notes := multiEnvNotes(map[string][]string{".env": {"KEY=remote"}})
+	bw := &mockBwClient{
+		folderID:   "folder-123",
+		itemByName: &FullItem{ID: "item-456", Name: "my-project", Notes: notes},
+	}
+	fs := &mockFileSystem{
+		dirEntries: []DirEntry{&mockDirEntry{name: ".env"}},
+		readContentMap: map[string][]byte{
+			".env": []byte("KEY=local"),
+		},
+	}
+	logger := &mockLogger{}
+	cfg := &config.Config{}
+
+	err := CleanEnvCore(
+		".",
+		"my-project",
+		fs,
+		bw,
+		cfg,
+		func() (string, error) { return "pwd", nil },
+		func(mismatched []string) (CleanMismatchAction, error) {
+			assert.Contains(t, mismatched, ".env")
+			return CleanActionOverwriteRemoteThenClean, nil
+		},
+		logger,
+	)
+
+	assert.NoError(t, err)
+	assert.Contains(t, bw.calls, "UpdateNoteItem(item-456)")
+	assert.Contains(t, fs.calls, "Remove(.env)")
+}
+
+// 正常系: 差分ありで remove local のみ
+func TestCleanEnvCore_RemoveLocalOnly(t *testing.T) {
+	notes := multiEnvNotes(map[string][]string{".env": {"KEY=remote"}})
+	bw := &mockBwClient{
+		folderID:   "folder-123",
+		itemByName: &FullItem{ID: "item-456", Name: "my-project", Notes: notes},
+	}
+	fs := &mockFileSystem{
+		dirEntries: []DirEntry{&mockDirEntry{name: ".env"}},
+		readContentMap: map[string][]byte{
+			".env": []byte("KEY=local"),
+		},
+	}
+	logger := &mockLogger{}
+	cfg := &config.Config{}
+
+	err := CleanEnvCore(
+		".",
+		"my-project",
+		fs,
+		bw,
+		cfg,
+		func() (string, error) { return "pwd", nil },
+		func(mismatched []string) (CleanMismatchAction, error) {
+			return CleanActionRemoveLocal, nil
+		},
+		logger,
+	)
+
+	assert.NoError(t, err)
+	assert.Contains(t, fs.calls, "Remove(.env)")
+	for _, call := range bw.calls {
+		assert.NotContains(t, call, "UpdateNoteItem")
+		assert.NotContains(t, call, "CreateNoteItem")
+	}
+}
+
+// 異常系: リモートアイテム無し
+func TestCleanEnvCore_RemoteItemMissing(t *testing.T) {
+	bw := &mockBwClient{
+		folderID:   "folder-123",
+		itemByName: nil,
+	}
+	fs := &mockFileSystem{
+		dirEntries: []DirEntry{&mockDirEntry{name: ".env"}},
+		readContentMap: map[string][]byte{
+			".env": []byte("KEY=value"),
+		},
+	}
+	logger := &mockLogger{}
+	cfg := &config.Config{}
+
+	err := CleanEnvCore(
+		".",
+		"my-project",
+		fs,
+		bw,
+		cfg,
+		func() (string, error) { return "pwd", nil },
+		func(mismatched []string) (CleanMismatchAction, error) {
+			return CleanActionRemoveLocal, nil
+		},
+		logger,
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Empty(t, fs.removedFiles)
+}
+
+// 異常系: リモートに管理対象ファイルが空
+func TestCleanEnvCore_RemoteEmptyFiles(t *testing.T) {
+	bw := &mockBwClient{
+		folderID:   "folder-123",
+		itemByName: &FullItem{ID: "item-456", Name: "my-project", Notes: `{}`},
+	}
+	fs := &mockFileSystem{
+		dirEntries: []DirEntry{&mockDirEntry{name: ".env"}},
+		readContentMap: map[string][]byte{
+			".env": []byte("KEY=value"),
+		},
+	}
+	logger := &mockLogger{}
+	cfg := &config.Config{}
+
+	err := CleanEnvCore(
+		".",
+		"my-project",
+		fs,
+		bw,
+		cfg,
+		func() (string, error) { return "pwd", nil },
+		func(mismatched []string) (CleanMismatchAction, error) {
+			return CleanActionRemoveLocal, nil
+		},
+		logger,
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no env files")
+	assert.Empty(t, fs.removedFiles)
+}
+
+// 異常系: 差分ありで Abort
+func TestCleanEnvCore_AbortOnMismatch(t *testing.T) {
+	notes := multiEnvNotes(map[string][]string{".env": {"KEY=remote"}})
+	bw := &mockBwClient{
+		folderID:   "folder-123",
+		itemByName: &FullItem{ID: "item-456", Name: "my-project", Notes: notes},
+	}
+	fs := &mockFileSystem{
+		dirEntries: []DirEntry{&mockDirEntry{name: ".env"}},
+		readContentMap: map[string][]byte{
+			".env": []byte("KEY=local"),
+		},
+	}
+	logger := &mockLogger{}
+	cfg := &config.Config{}
+
+	err := CleanEnvCore(
+		".",
+		"my-project",
+		fs,
+		bw,
+		cfg,
+		func() (string, error) { return "pwd", nil },
+		func(mismatched []string) (CleanMismatchAction, error) {
+			return CleanActionAbort, nil
+		},
+		logger,
+	)
+
+	assert.ErrorIs(t, err, ErrCleanAborted)
+	assert.Empty(t, fs.removedFiles)
+	for _, call := range bw.calls {
+		assert.NotContains(t, call, "UpdateNoteItem")
+	}
+}
+
+// 正常系: 複数ファイルのうち1つでも差分があれば差分扱い
+func TestCleanEnvCore_OneFileDiffTreatsAsMismatch(t *testing.T) {
+	notes := multiEnvNotes(map[string][]string{
+		".env":         {"KEY=value"},
+		".env.staging": {"ENV=staging"},
+	})
+	bw := &mockBwClient{
+		folderID:   "folder-123",
+		itemByName: &FullItem{ID: "item-456", Name: "my-project", Notes: notes},
+	}
+	fs := &mockFileSystem{
+		dirEntries: []DirEntry{
+			&mockDirEntry{name: ".env"},
+			&mockDirEntry{name: ".env.staging"},
+		},
+		readContentMap: map[string][]byte{
+			".env":         []byte("KEY=value"),
+			".env.staging": []byte("ENV=changed"),
+		},
+	}
+	logger := &mockLogger{}
+	cfg := &config.Config{}
+	var gotMismatched []string
+
+	err := CleanEnvCore(
+		".",
+		"my-project",
+		fs,
+		bw,
+		cfg,
+		func() (string, error) { return "pwd", nil },
+		func(mismatched []string) (CleanMismatchAction, error) {
+			gotMismatched = mismatched
+			return CleanActionAbort, nil
+		},
+		logger,
+	)
+
+	assert.ErrorIs(t, err, ErrCleanAborted)
+	assert.Contains(t, gotMismatched, ".env.staging")
+	assert.Empty(t, fs.removedFiles)
 }
 
 // =============================================================================

--- a/app/src/infra/bwclient_mock.go
+++ b/app/src/infra/bwclient_mock.go
@@ -52,6 +52,18 @@ func (fs *MockFileSystem) WriteFile(path string, data []byte, perm uint32) error
 	return nil
 }
 
+// Remove はファイルを削除します。
+func (fs *MockFileSystem) Remove(path string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if _, ok := fs.files[path]; !ok {
+		return fmt.Errorf("file not found: %s", path)
+	}
+	delete(fs.files, path)
+	return nil
+}
+
 // Stat はファイル情報を取得します。
 func (fs *MockFileSystem) Stat(path string) (core.FileInfo, error) {
 	fs.mu.RLock()
@@ -152,7 +164,7 @@ func (fi *mockFileInfo) IsNotExist() bool {
 
 // MockLogger はテスト用のモック Logger 実装です。
 type MockLogger struct {
-	mu       sync.Mutex
+	mu        sync.Mutex
 	InfoLogs  []string
 	ErrorLogs []string
 }
@@ -189,9 +201,9 @@ type MockBwClient struct {
 	mu sync.RWMutex
 
 	// ストレージ
-	folders map[string]string          // folderName -> folderID
-	items   map[string]*core.FullItem  // itemID -> FullItem
-	itemsByFolder map[string][]string  // folderID -> []itemID
+	folders       map[string]string         // folderName -> folderID
+	items         map[string]*core.FullItem // itemID -> FullItem
+	itemsByFolder map[string][]string       // folderID -> []itemID
 
 	// 認証状態
 	isLoggedIn bool
@@ -468,4 +480,3 @@ func (m *MockBwClient) Reset() {
 	m.password = ""
 	m.serverURL = ""
 }
-

--- a/app/src/infra/filesystem.go
+++ b/app/src/infra/filesystem.go
@@ -29,6 +29,11 @@ func (fs *RealFileSystem) WriteFile(path string, data []byte, perm uint32) error
 	return os.WriteFile(path, data, os.FileMode(perm))
 }
 
+// Remove はファイルを削除します。
+func (fs *RealFileSystem) Remove(path string) error {
+	return os.Remove(path)
+}
+
 // Stat はファイル情報を取得します。
 func (fs *RealFileSystem) Stat(path string) (core.FileInfo, error) {
 	_, err := os.Stat(path)
@@ -84,4 +89,3 @@ func (de *realDirEntry) Name() string {
 func (de *realDirEntry) IsDir() bool {
 	return de.entry.IsDir()
 }
-

--- a/app/src/infra/infra_test.go
+++ b/app/src/infra/infra_test.go
@@ -50,6 +50,7 @@ func TestRealFileSystem_ImplementsInterface(t *testing.T) {
 	assert.NotNil(t, fs.OpenEnvFile)
 	assert.NotNil(t, fs.ReadFile)
 	assert.NotNil(t, fs.WriteFile)
+	assert.NotNil(t, fs.Remove)
 	assert.NotNil(t, fs.Stat)
 	assert.NotNil(t, fs.MkdirAll)
 }
@@ -111,8 +112,3 @@ func TestRealFileInfo_IsNotExist_False(t *testing.T) {
 
 	assert.False(t, info.IsNotExist())
 }
-
-
-
-
-

--- a/app/src/utils/input.go
+++ b/app/src/utils/input.go
@@ -112,3 +112,50 @@ func ConfirmYesNo(message string) (bool, error) {
 	response := strings.TrimSpace(strings.ToLower(input))
 	return response == "y" || response == "yes", nil
 }
+
+// CleanMismatchAction labels returned by SelectCleanMismatchAction.
+const (
+	CleanMismatchAbort                    = "abort"
+	CleanMismatchOverwriteRemoteThenClean = "overwrite_remote_then_clean"
+	CleanMismatchRemoveLocal              = "remove_local"
+)
+
+// SelectCleanMismatchAction prompts for a single action when local/remote contents differ.
+// Options are presented as a radio-style single select (Abort first for safety).
+func SelectCleanMismatchAction(mismatchedFiles []string) (string, error) {
+	Warningln("[bwsf Alert] File contents on remote are mismatch.")
+	if len(mismatchedFiles) > 0 {
+		Infoln("[INFO] Mismatched file(s):")
+		for _, name := range mismatchedFiles {
+			Infoln("  -", name)
+		}
+	}
+	Infoln("Are you sure to remove files from local?")
+
+	items := []string{
+		"Abort",
+		"Overwrite remote with my local, then clean",
+		"Remove local without updating remote (DANGER)",
+	}
+
+	prompt := promptui.Select{
+		Label: "Select an action",
+		Items: items,
+	}
+
+	index, _, err := prompt.Run()
+	if err != nil {
+		return CleanMismatchAbort, fmt.Errorf("failed to select clean action: %w", err)
+	}
+
+	switch index {
+	case 0:
+		return CleanMismatchAbort, nil
+	case 1:
+		return CleanMismatchOverwriteRemoteThenClean, nil
+	case 2:
+		return CleanMismatchRemoveLocal, nil
+	default:
+		return CleanMismatchAbort, nil
+	}
+}

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -469,6 +469,23 @@
 - 異常系
   - `SetupBitwardenCore` がエラーを返す場合に、その内容がエラーとして表示され、`os.Exit(1)` が呼ばれることを確認する。
 
+### runClean
+
+- 処理:
+  - `--from` フラグをパースして対象ディレクトリを取得する。
+  - `os.Getwd()` から `projectName` を決定する。
+  - 具象 `BwClient` / `FileSystem` / `Logger` を生成する。
+  - 差分時の単一選択 UI (`SelectCleanMismatchAction`) を `CleanEnvCore` へ渡す。
+  - `CleanEnvCore` の戻り値が `ErrCleanAborted` の場合は情報メッセージを出して終了コード 0。
+  - その他のエラーはメッセージ表示＋`os.Exit(1)`、成功時は成功メッセージを表示する。
+
+#### テストシナリオ
+
+- 正常系
+  - `clean` コマンドが root に登録され、`--from` フラグのデフォルトが `"."` であることを確認する。
+- 異常系
+  - （コア層で担保）リモート未整備や Abort 時にローカル削除が行われないことを確認する。
+
 ---
 
 ## 6. 既存ユーティリティの仕様（インフラ実装側）

--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -25,11 +25,11 @@
 ### レイヤ構造の方針
 
 - **CLI 層**
-  - Cobra コマンド (`runPush`, `runPull`, `runList`, `runSetup`) からなる。
+  - Cobra コマンド (`runPush`, `runPull`, `runList`, `runSetup`, `runClean`) からなる。
   - 引数／フラグのパースと、エラー時の Exit/メッセージ表示のみを担当する「薄いラッパー」とする。
   - 実際の処理はすべて「コアロジック層」の関数に委譲する。
 - **コアロジック層**
-  - ビジネスロジック（Push/Pull/List/Setup）を環境依存のない形で実装する。
+  - ビジネスロジック（Push/Pull/List/Setup/Clean）を環境依存のない形で実装する。
   - I/O は `FileSystem` / `BwClient` / `Logger` インターフェースに抽象化する。
 - **インフラ層**
   - `exec.Command` による `bw` CLI 呼び出しや、`os` ベースのファイル操作など、現行実装に近い具体クラスを持つ。
@@ -186,6 +186,11 @@
 - 任意パスに文字列を保存する。
 - パーミッションは呼び出し側（コアロジック）から指定できるようにする。
 
+#### Remove
+
+- 任意パスのファイルを削除する。
+- 存在しない場合はエラーを返す（呼び出し側で必要なら事前に存在確認する）。
+
 #### Stat
 
 - 任意パスの存在確認／属性取得を行う。
@@ -201,8 +206,10 @@
 - 正常系
   - 既存ディレクトリに対して `MkdirAll` を呼び出してもエラーが発生しないことを確認する。
   - `WriteFile` 後に `ReadFile` で同じ内容が取得できることを確認する。
+  - `WriteFile` 後に `Remove` すると、以降の `Stat` / `ReadFile` で存在しない扱いになることを確認する。
 - 異常系
   - 読み取り専用ディレクトリ配下に `WriteFile` を試みた際にエラーが返ることを確認する（実環境ではスキップ可・モックで代用可）。
+  - 存在しないパスに対する `Remove` がエラーを返すことを確認する。
 
 ### Logger インターフェース
 
@@ -323,6 +330,33 @@
   - `bw.GetItemByName` が `nil, nil`（アイテム無し）を返すケースで、「Item not found」系エラーが返ることを確認する。
   - 既存 `.env` がある状態で `confirmOverwrite` が `false` を返す場合に、上書き処理を行わず、適切にキャンセル扱いになることを確認する。
   - `RestoreEnvFileFromJSON` が壊れた JSON でエラーを返す場合に、そのエラーがそのまま呼び出し元へ伝播することを確認する。
+
+### CleanEnvCore
+
+- シグネチャ（イメージ）:
+  - `func CleanEnvCore(targetDir, projectName string, fs FileSystem, bw BwClient, cfg *config.Config, promptPassword func() (string, error), selectMismatchAction func(mismatchedFiles []string) (CleanMismatchAction, error), logger Logger) error`
+- 処理:
+  - `FindEnvFiles` と同一のルール（`.env*` かつ `.example` 除外）でローカル対象ファイルを検出する。
+  - ローカルに対象ファイルが無い場合はエラーを返す。
+  - `WithUnlockRetry` 経由で `bw.GetDotenvsFolderID()` / `bw.GetItemByName(folderID, projectName)` を実行し、dotenvs 配下の同名 Note アイテムを取得する。
+  - アイテムが存在しない、またはアイテム内に管理対象ファイルが無い場合は、ローカルを削除せずエラーで中止する。
+  - ローカルとリモートの `MultiEnvData` を比較する。1 ファイルでも差分（欠落含む）があればプロジェクト全体を差分ありとみなす。
+  - 差分が無い場合は確認なしでローカル対象ファイルを `fs.Remove` する。
+  - 差分がある場合は `selectMismatchAction` で単一選択させる（Abort / Overwrite remote then clean / Remove local）。
+    - Abort: 削除せず中止（`ErrCleanAborted`）。
+    - Overwrite remote then clean: ローカル内容でリモートを更新（push 相当）してからローカルを削除する。
+    - Remove local: リモートを更新せずローカルのみ削除する（危険選択肢）。
+
+#### テストシナリオ
+
+- 正常系
+  - リモート同名アイテムがあり内容が一致する場合に、確認コールバックを呼ばずローカル `.env*` が `Remove` されることを確認する。
+  - 差分があり `Overwrite remote then clean` が選ばれた場合に、`UpdateNoteItem`（または作成）の後にローカルが削除されることを確認する。
+  - 差分があり `Remove local` が選ばれた場合に、リモート更新なしでローカルのみ削除されることを確認する。
+- 異常系
+  - リモートに同名アイテムが無い場合に、ローカルを削除せずエラーになることを確認する。
+  - リモートアイテムはあるが管理対象ファイルが空の場合に、ローカルを削除せずエラーになることを確認する。
+  - 差分ありで `Abort` が選ばれた場合に、ローカルもリモートも変更されないことを確認する。
 
 ### ListDotenvsCore
 

--- a/docs/site/en/guide/commands.md
+++ b/docs/site/en/guide/commands.md
@@ -8,6 +8,7 @@
 | `bwsf push` | Push .env files to Bitwarden |
 | `bwsf pull` | Pull .env files from Bitwarden |
 | `bwsf list` | List all stored projects |
+| `bwsf clean` | Remove local .env files after verifying Bitwarden backup |
 
 ## bwsf setup
 
@@ -112,6 +113,28 @@ Projects in Bitwarden:
   • api-server
   • mobile-app
 ```
+
+## bwsf clean
+
+Remove bwsf-managed local `.env*` files after verifying the Bitwarden backup.
+
+```bash
+cd /path/to/your_project
+bwsf clean
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--from <dir>` | Directory containing .env files to clean (default: current directory) |
+
+### Behavior
+
+1. Uses the current directory name as the project name
+2. Aborts if the remote note item is missing or contains no managed files
+3. Deletes local files without prompting when contents match
+4. On any file mismatch, prompts with a single-select action (Abort / Overwrite remote then clean / Remove local)
 
 ## Common Workflows
 

--- a/docs/site/ja/guide/commands.md
+++ b/docs/site/ja/guide/commands.md
@@ -8,6 +8,7 @@
 | `bwsf push` | .env ファイルを Bitwarden にプッシュ |
 | `bwsf pull` | .env ファイルを Bitwarden からプル |
 | `bwsf list` | 保存されている全プロジェクトを一覧表示 |
+| `bwsf clean` | リモートバックアップ確認後にローカル .env を削除 |
 
 ## bwsf setup
 
@@ -112,6 +113,28 @@ Projects in Bitwarden:
   • api-server
   • mobile-app
 ```
+
+## bwsf clean
+
+Bitwarden 側のバックアップを確認したうえで、ローカルの管理対象 `.env*` を削除します。
+
+```bash
+cd /path/to/your_project
+bwsf clean
+```
+
+### オプション
+
+| オプション | 説明 |
+|---|---|
+| `--from <dir>` | 削除対象ディレクトリを指定（デフォルト: カレントディレクトリ） |
+
+### 挙動
+
+1. カレントディレクトリ名をプロジェクト名として使う
+2. リモートに同名 Note アイテムが無い、または管理対象ファイルが空なら中止する
+3. 内容が一致すれば確認なしでローカルを削除する
+4. 1 ファイルでも差分があれば単一選択で分岐する（Abort / Overwrite remote then clean / Remove local）
 
 ## よくあるワークフロー
 


### PR DESCRIPTION
## Summary
- Closes #100
- Add `bwsf clean` to remove bwsf-managed local `.env*` files after verifying the Bitwarden note item backup
- On content mismatch, prompt with Abort / Overwrite remote then clean / Remove local (DANGER)

## Test plan
- [x] `go test ./...` in `app/`
- [ ] Manual: matching remote deletes local without prompt
- [ ] Manual: missing remote aborts
- [ ] Manual: mismatch Abort keeps local
- [ ] Manual: mismatch overwrite-then-clean updates remote then deletes local