### PR TITLE
chore: bump Go to 1.26 for API backend SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Download dependencies
         working-directory: app
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Download dependencies
         working-directory: app

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine
+FROM golang:1.26-alpine
 
 WORKDIR /app
 

--- a/app/go.mod
+++ b/app/go.mod
@@ -1,6 +1,6 @@
 module bwsf
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/briandowns/spinner v1.23.2


### PR DESCRIPTION
## Summary
- Bump the bwsf app and CI/Docker toolchain from Go 1.25 to Go 1.26 so the API backend SDK (Issue #53 Step 3 PR-A) can build against the required language version.
- Updates `app/go.mod`, `app/Dockerfile`, and GitHub Actions `test` / `release` workflows only — no Unlock or setup behavior changes.

## Related
- Issue #53 — Step 3 PR-A (Go version bump)

## Test plan
- [x] `cd app && GOENV_VERSION=1.25.7 GOTOOLCHAIN=auto go test ./...`
- [ ] CI unit + e2e jobs on this PR