### PR TITLE
feat: separate setup from auth for API backend (#53)

### DIFF
--- a/app/src/cmd/cmd_test.go
+++ b/app/src/cmd/cmd_test.go
@@ -159,6 +159,8 @@ func TestListCmd_Description(t *testing.T) {
 func TestSetupCmd_Description(t *testing.T) {
 	assert.NotEmpty(t, setupCmd.Short)
 	assert.NotEmpty(t, setupCmd.Long)
+	// backend=api では認証が bwsf auth に分離されることを案内する
+	assert.Contains(t, setupCmd.Long, "bwsf auth")
 }
 
 // 正常系: backend コマンドに説明がある

--- a/app/src/cmd/setup.go
+++ b/app/src/cmd/setup.go
@@ -13,7 +13,7 @@ import (
 var setupCmd = &cobra.Command{
 	Use:   "setup",
 	Short: "Setup Bitwarden host configuration",
-	Long:  "Configure Bitwarden host (Cloud or Self-hosted) and login credentials",
+	Long:  "Configure Bitwarden host (Cloud or Self-hosted). For backend=bw, also login. For backend=api, use `bwsf auth` after setup.",
 	Run:   runSetup,
 }
 
@@ -24,22 +24,44 @@ func init() {
 func runSetup(cmd *cobra.Command, args []string) {
 	cfg := loadConfigOrEmpty()
 	if cfg.GetBackend() == config.BackendAPI {
-		utils.Infoln("[INFO] backend=api: use `bwsf auth` to store a Personal API Key and obtain an Identity token.")
-		utils.Infoln("[INFO] Continuing setup will still configure host/email for Identity URL resolution.")
+		runSetupAPI()
+		return
 	}
+	runSetupBW(cfg)
+}
+
+// runSetupAPI configures host/email only. Auth is via `bwsf auth`.
+func runSetupAPI() {
+	utils.Infoln("[INFO] backend=api: setup configures host/email only.")
+	utils.Infoln("[INFO] Use `bwsf auth` afterward to store a Personal API Key and obtain an Identity token.")
+
+	logger := infra.NewLogger()
+	err := core.SetupAPIConfigCore(
+		logger,
+		utils.SelectHostType,
+		utils.InputURL,
+		utils.InputEmail,
+	)
+	if err != nil {
+		utils.Errorln("[ERROR]", err)
+		os.Exit(1)
+	}
+
+	utils.Successln("[INFO] ✅ Configuration saved. Run `bwsf auth` to authenticate for API backend.")
+}
+
+// runSetupBW keeps the existing CLI Login + folder setup flow.
+func runSetupBW(cfg *config.Config) {
 	requireBwCLIIfNeeded(cfg)
 
-	// Create dependencies
 	bw := newBwClientFromConfig(cfg)
 	fs := infra.NewFileSystem()
 	logger := infra.NewLogger()
 
-	// confirmCreateFolder wrapper
 	confirmCreateFolder := func() (bool, error) {
 		return utils.ConfirmYesNo("dotenvs folder not found. Create it? (y/N): ")
 	}
 
-	// Call core logic
 	err := core.SetupBitwardenCore(
 		fs,
 		bw,
@@ -55,6 +77,5 @@ func runSetup(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	// Success message
 	utils.Successln("[INFO] ✅ Sign in to Bitwarden was successful!")
 }

--- a/app/src/core/core.go
+++ b/app/src/core/core.go
@@ -495,6 +495,89 @@ func ListDotenvsCore(
 	return items, nil
 }
 
+// collectHostEmailConfig prompts for host type, optional self-hosted URL, and email.
+func collectHostEmailConfig(
+	selectHostType func() (string, error),
+	inputURL func() (string, error),
+	inputEmail func() (string, error),
+) (hostType, selfhostedURL, email string, err error) {
+	hostType, err = selectHostType()
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to select host type: %w", err)
+	}
+
+	if hostType == "selfhosted" {
+		selfhostedURL, err = inputURL()
+		if err != nil {
+			return "", "", "", fmt.Errorf("failed to get URL: %w", err)
+		}
+		if strings.TrimSpace(selfhostedURL) == "" {
+			return "", "", "", fmt.Errorf("self-hosted URL cannot be empty")
+		}
+	}
+
+	email, err = inputEmail()
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to get email: %w", err)
+	}
+	if strings.TrimSpace(email) == "" {
+		return "", "", "", fmt.Errorf("email cannot be empty")
+	}
+
+	return hostType, selfhostedURL, email, nil
+}
+
+// preserveSetupFields copies fields that setup must not wipe (backend, device id).
+func preserveSetupFields(newConfig, existing *config.Config) {
+	if existing == nil {
+		return
+	}
+	newConfig.Backend = existing.Backend
+	newConfig.DeviceIdentifier = existing.DeviceIdentifier
+}
+
+// SetupAPIConfigCore configures host/email for the API backend without Login.
+// Authentication is performed separately via `bwsf auth`. Folder creation is
+// skipped until Issue #53 Step 4 implements API vault operations.
+func SetupAPIConfigCore(
+	logger Logger,
+	selectHostType func() (string, error),
+	inputURL func() (string, error),
+	inputEmail func() (string, error),
+) error {
+	existingConfig, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load existing config: %w", err)
+	}
+	if existingConfig != nil {
+		logger.Info("Existing configuration found. Host/email settings will be updated.")
+	}
+
+	hostType, selfhostedURL, email, err := collectHostEmailConfig(selectHostType, inputURL, inputEmail)
+	if err != nil {
+		return err
+	}
+
+	newConfig := &config.Config{
+		HostType:      hostType,
+		SelfhostedURL: selfhostedURL,
+		Email:         email,
+		Backend:       config.BackendAPI,
+	}
+	preserveSetupFields(newConfig, existingConfig)
+	// Ensure API backend remains selected even when no prior config existed.
+	if newConfig.Backend == "" {
+		newConfig.Backend = config.BackendAPI
+	}
+
+	if err := config.SaveConfig(newConfig); err != nil {
+		return fmt.Errorf("failed to save configuration: %w", err)
+	}
+
+	logger.Info("Configuration saved. Run `bwsf auth` to authenticate with a Personal API Key.")
+	return nil
+}
+
 // SetupBitwardenCore は Bitwarden のセットアップを行うコアロジックです。
 func SetupBitwardenCore(
 	fs FileSystem,
@@ -515,25 +598,9 @@ func SetupBitwardenCore(
 		logger.Info("Existing configuration found. It will be overwritten.")
 	}
 
-	// ホストタイプを選択
-	hostType, err := selectHostType()
+	hostType, selfhostedURL, email, err := collectHostEmailConfig(selectHostType, inputURL, inputEmail)
 	if err != nil {
-		return fmt.Errorf("failed to select host type: %w", err)
-	}
-
-	// Self-hosted の場合は URL を入力
-	var selfhostedURL string
-	if hostType == "selfhosted" {
-		selfhostedURL, err = inputURL()
-		if err != nil {
-			return fmt.Errorf("failed to get URL: %w", err)
-		}
-	}
-
-	// メールアドレスを入力
-	email, err := inputEmail()
-	if err != nil {
-		return fmt.Errorf("failed to get email: %w", err)
+		return err
 	}
 
 	// パスワードを入力
@@ -547,15 +614,13 @@ func SetupBitwardenCore(
 		return fmt.Errorf("failed to login: %w", err)
 	}
 
-	// 設定を保存（既存の backend 設定は維持）
+	// 設定を保存（既存の backend / device_identifier は維持）
 	newConfig := &config.Config{
 		HostType:      hostType,
 		SelfhostedURL: selfhostedURL,
 		Email:         email,
 	}
-	if existingConfig != nil {
-		newConfig.Backend = existingConfig.Backend
-	}
+	preserveSetupFields(newConfig, existingConfig)
 	if err := config.SaveConfig(newConfig); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}

--- a/app/src/core/core_test.go
+++ b/app/src/core/core_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"bwsf/src/config"
@@ -2128,4 +2130,155 @@ func TestSortFileNames(t *testing.T) {
 	assert.Equal(t, ".env.local", names[1])
 	assert.Equal(t, ".env.production", names[2])
 	assert.Equal(t, ".env.staging", names[3])
+}
+
+// =============================================================================
+// SetupAPIConfigCore のテスト（docs/tests/cmd/setup_api.md）
+// =============================================================================
+
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+	t.Cleanup(func() { os.Setenv("HOME", origHome) })
+	return tmpDir
+}
+
+// 正常系: backend=api で config が保存され、Login が不要（呼ばれない）
+func TestSetupAPIConfigCore_CloudSuccess_NoLogin(t *testing.T) {
+	withTempHome(t)
+	_ = config.SaveConfig(&config.Config{
+		Backend:          config.BackendAPI,
+		DeviceIdentifier: "device-preserve-me",
+	})
+	logger := &mockLogger{}
+	bw := &mockBwClient{}
+
+	err := SetupAPIConfigCore(
+		logger,
+		func() (string, error) { return "cloud", nil },
+		func() (string, error) { return "", errors.New("should not be called") },
+		func() (string, error) { return "api@example.com", nil },
+	)
+
+	assert.NoError(t, err)
+	assert.Empty(t, bw.calls, "Login must not be called for API setup")
+
+	cfg, loadErr := config.LoadConfig()
+	assert.NoError(t, loadErr)
+	assert.Equal(t, "cloud", cfg.HostType)
+	assert.Equal(t, "", cfg.SelfhostedURL)
+	assert.Equal(t, "api@example.com", cfg.Email)
+	assert.Equal(t, config.BackendAPI, cfg.Backend)
+	assert.Equal(t, "device-preserve-me", cfg.DeviceIdentifier)
+
+	joined := fmt.Sprint(logger.infos)
+	assert.Contains(t, joined, "bwsf auth")
+}
+
+// 正常系: selfhosted + URL を保存し、Login しない
+func TestSetupAPIConfigCore_SelfhostedSuccess_NoLogin(t *testing.T) {
+	withTempHome(t)
+	_ = config.SaveConfig(&config.Config{Backend: config.BackendAPI})
+	logger := &mockLogger{}
+
+	err := SetupAPIConfigCore(
+		logger,
+		func() (string, error) { return "selfhosted", nil },
+		func() (string, error) { return "https://vw.example.com", nil },
+		func() (string, error) { return "api@example.com", nil },
+	)
+
+	assert.NoError(t, err)
+	cfg, loadErr := config.LoadConfig()
+	assert.NoError(t, loadErr)
+	assert.Equal(t, "selfhosted", cfg.HostType)
+	assert.Equal(t, "https://vw.example.com", cfg.SelfhostedURL)
+	assert.Equal(t, "api@example.com", cfg.Email)
+	assert.Equal(t, config.BackendAPI, cfg.Backend)
+}
+
+// 正常系: auth 未実施でも setup 自体は設定更新として成功する
+func TestSetupAPIConfigCore_SucceedsWithoutPriorAuth(t *testing.T) {
+	withTempHome(t)
+	// Only backend=api; no auth/token state is required for setup.
+	_ = config.SaveConfig(&config.Config{Backend: config.BackendAPI})
+	logger := &mockLogger{}
+
+	err := SetupAPIConfigCore(
+		logger,
+		func() (string, error) { return "cloud", nil },
+		func() (string, error) { return "", nil },
+		func() (string, error) { return "fresh@example.com", nil },
+	)
+
+	assert.NoError(t, err)
+	cfg, _ := config.LoadConfig()
+	assert.Equal(t, "fresh@example.com", cfg.Email)
+}
+
+// 異常系: selfhosted で URL が空の場合は保存せずエラー
+func TestSetupAPIConfigCore_EmptySelfhostedURL(t *testing.T) {
+	home := withTempHome(t)
+	_ = config.SaveConfig(&config.Config{Backend: config.BackendAPI, Email: "old@example.com"})
+	logger := &mockLogger{}
+
+	err := SetupAPIConfigCore(
+		logger,
+		func() (string, error) { return "selfhosted", nil },
+		func() (string, error) { return "   ", nil },
+		func() (string, error) { return "api@example.com", nil },
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "URL cannot be empty")
+
+	cfg, _ := config.LoadConfig()
+	assert.Equal(t, "old@example.com", cfg.Email, "config must not be overwritten on validation failure")
+	content, _ := os.ReadFile(filepath.Join(home, ".config", "bwsf", "config.json"))
+	assert.NotContains(t, string(content), "api@example.com")
+}
+
+// 異常系: 設定保存に失敗した場合はエラー（Login 経路は存在しない）
+func TestSetupAPIConfigCore_SaveConfigError(t *testing.T) {
+	home := withTempHome(t)
+	configDir := filepath.Join(home, ".config", "bwsf")
+	assert.NoError(t, os.MkdirAll(configDir, 0755))
+	// No config file yet (LoadConfig → nil). Directory is read-only so create fails.
+	assert.NoError(t, os.Chmod(configDir, 0500))
+	t.Cleanup(func() { _ = os.Chmod(configDir, 0755) })
+	logger := &mockLogger{}
+
+	err := SetupAPIConfigCore(
+		logger,
+		func() (string, error) { return "cloud", nil },
+		func() (string, error) { return "", nil },
+		func() (string, error) { return "api@example.com", nil },
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save configuration")
+}
+
+// 退行: backend=bw の SetupBitwardenCore は従来どおり Login を呼ぶ
+func TestSetupBitwardenCore_StillCallsLogin(t *testing.T) {
+	withTempHome(t)
+	bw := &mockBwClient{folderExists: true}
+	fs := &mockFileSystem{}
+	logger := &mockLogger{}
+
+	err := SetupBitwardenCore(
+		fs,
+		bw,
+		logger,
+		func() (string, error) { return "cloud", nil },
+		func() (string, error) { return "", errors.New("should not be called") },
+		func() (string, error) { return "bw@example.com", nil },
+		func() (string, error) { return "password123", nil },
+		func() (bool, error) { return false, nil },
+	)
+
+	assert.NoError(t, err)
+	assert.Contains(t, bw.calls, "Login(bw@example.com,)")
 }


### PR DESCRIPTION
## Summary

Step 3 PR-B for Issue #53: when `backend=api`, `bwsf setup` configures host/email only and does **not** Login with a master password. Authentication remains `bwsf auth`.

- Add `SetupAPIConfigCore` (host type / self-hosted URL / email → save config; preserve `Backend` + `DeviceIdentifier`; no Login / no password prompt; skip folder create until Step 4)
- Route `runSetup` so `backend=api` uses the config-only path and success copy reminds users to run `bwsf auth` (no “Sign in was successful”)
- Keep `SetupBitwardenCore` Login + folder flow for `backend=bw`
- Unit tests per `docs/tests/cmd/setup_api.md`

Related: #53

## Test plan

- [x] `cd app && GOENV_VERSION=1.25.7 GOTOOLCHAIN=auto go test ./src/core/... ./src/cmd/... ./src/infra/... ./src/config/...`
- [ ] Manual: `bwsf backend --set api` → `bwsf setup` prompts host/email only, saves config, prints `bwsf auth` hint
- [ ] Manual: `bwsf backend --set bw` → existing setup Login flow still works