### PR TITLE
feat: Step 3 API vault unlock and session lifecycle (#53)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Download dependencies
         working-directory: app
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Download dependencies
         working-directory: app

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ bwsf auth
 
 Create a Personal API Key in the Bitwarden web vault under Account Settings → Security → Keys.
 
-Vault unlock and push/pull over the API are not implemented yet; keep using `backend=bw` for day-to-day sync.
+Vault unlock (master password → decryption keys in memory) is implemented for `backend=api` (Step 3). Keys are discarded when each command exits. Push/pull/list vault CRUD over the API is still stubbed (Step 4); keep using `backend=bw` for day-to-day sync until then.
+
+Caveat: unlock currently uses the Community SDK password-login path with config email + master password for key material. Identity Personal API Key tokens remain separate (Scenario C).
 
 ## Uninstall
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -141,7 +141,9 @@ bwsf auth
 
 Personal API Key は Bitwarden Web 保管庫の アカウント設定 → セキュリティ → キー から作成できます。
 
-API 経由のボルト unlock や push/pull は未実装です。日常利用は当面 `backend=bw` を使ってください。
+API 経由のボルト unlock（マスターパスワード → メモリ上の復号鍵）は実装済みです（Step 3）。鍵は各コマンド終了時に破棄されます。push/pull/list の保管庫 CRUD はまだ stub です（Step 4）。日常の同期は当面 `backend=bw` を使ってください。
+
+補足: unlock は現状、Community SDK のパスワード login 経路（config の email + マスターパスワード）で鍵を復元します。Identity の Personal API Key トークンとは別管理です（Scenario C）。
 
 ## アンインストール
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine
+FROM golang:1.26-alpine
 
 WORKDIR /app
 

--- a/app/go.mod
+++ b/app/go.mod
@@ -1,6 +1,6 @@
 module bwsf
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/briandowns/spinner v1.23.2

--- a/app/go.mod
+++ b/app/go.mod
@@ -3,6 +3,7 @@ module bwsf
 go 1.26
 
 require (
+	github.com/bnema/bitwarden-go-sdk v0.4.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/google/uuid v1.6.0
 	github.com/manifoldco/promptui v0.9.0
@@ -23,6 +24,7 @@ require (
 	github.com/mattn/go-isatty v0.0.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/app/go.sum
+++ b/app/go.sum
@@ -1,3 +1,5 @@
+github.com/bnema/bitwarden-go-sdk v0.4.0 h1:O7zAWX/++bZl5WDwZ5Fa8OKnBtkuJe9xDK1+7dN6CQo=
+github.com/bnema/bitwarden-go-sdk v0.4.0/go.mod h1:z9ZZyeUnDC1CZ/TwboEJ7fsaEmLwnqWIozdbkG5+JCY=
 github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
 github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
@@ -40,6 +42,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
+golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=

--- a/app/src/cmd/auth.go
+++ b/app/src/cmd/auth.go
@@ -78,7 +78,7 @@ func runAuth(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	client := infra.NewApiBwClientWithDeps(cfg, store, infra.NewIdentityClient())
+	client := infra.NewApiBwClientWithDeps(cfg, store, infra.NewIdentityClient(), nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -89,7 +89,7 @@ func runAuth(cmd *cobra.Command, args []string) {
 
 	utils.Successln("[INFO] ✅ Authenticated with Personal API Key (token stored in memory for this process)")
 	utils.Infoln("[INFO] Personal API Key is stored in the OS secret store (Keychain / secret service)")
-	utils.Infoln("[INFO] Vault unlock and push/pull via API are not implemented yet")
+	utils.Infoln("[INFO] Vault CRUD via API is not implemented yet (Issue #53 Step 4)")
 }
 
 func ensureHostConfigForAPI(cfg *config.Config) error {

--- a/app/src/cmd/client.go
+++ b/app/src/cmd/client.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 
 	"bwsf/src/config"
@@ -8,6 +9,28 @@ import (
 	"bwsf/src/infra"
 	"bwsf/src/utils"
 )
+
+type sessionClearer interface {
+	ClearSession()
+}
+
+func clearAPISession(bw core.BwClient) {
+	if c, ok := bw.(sessionClearer); ok {
+		c.ClearSession()
+	}
+}
+
+func reportCommandError(err error) {
+	if err == nil {
+		return
+	}
+	if core.IsNotAuthenticatedError(err) || errors.Is(err, infra.ErrAPINotAuthenticated) {
+		utils.Errorln("[ERROR]", err)
+		utils.Infoln("[INFO] Run: bwsf auth")
+		return
+	}
+	utils.Errorln("[ERROR]", err)
+}
 
 // loadConfigOrEmpty loads ~/.config/bwsf/config.json, or returns an empty config when missing.
 func loadConfigOrEmpty() *config.Config {

--- a/app/src/cmd/list.go
+++ b/app/src/cmd/list.go
@@ -27,6 +27,7 @@ func runList(cmd *cobra.Command, args []string) {
 
 	// Create dependencies
 	bw := newBwClientFromConfig(cfg)
+	defer clearAPISession(bw)
 	logger := infra.NewLogger()
 
 	// Call core logic
@@ -37,7 +38,7 @@ func runList(cmd *cobra.Command, args []string) {
 		logger,
 	)
 	if err != nil {
-		utils.Errorln("[ERROR]", err)
+		reportCommandError(err)
 		os.Exit(1)
 	}
 

--- a/app/src/cmd/pull.go
+++ b/app/src/cmd/pull.go
@@ -44,13 +44,14 @@ func runPull(cmd *cobra.Command, args []string) {
 
 	// Create dependencies
 	bw := newBwClientFromConfig(cfg)
+	defer clearAPISession(bw)
 	fs := infra.NewFileSystem()
 	logger := infra.NewLogger()
 
 	// Get list of env files to be pulled
 	envFiles, err := core.GetPulledEnvFiles(projectName, bw, cfg, utils.InputPassword, logger)
 	if err != nil {
-		utils.Errorln("[ERROR] Failed to get env files info:", err)
+		reportCommandError(err)
 		os.Exit(1)
 	}
 
@@ -82,7 +83,7 @@ func runPull(cmd *cobra.Command, args []string) {
 		logger,
 	)
 	if err != nil {
-		utils.Errorln("[ERROR]", err)
+		reportCommandError(err)
 		os.Exit(1)
 	}
 

--- a/app/src/cmd/push.go
+++ b/app/src/cmd/push.go
@@ -43,6 +43,7 @@ func runPush(cmd *cobra.Command, args []string) {
 
 	// Create dependencies
 	bw := newBwClientFromConfig(cfg)
+	defer clearAPISession(bw)
 	fs := infra.NewFileSystem()
 	logger := infra.NewLogger()
 
@@ -75,7 +76,7 @@ func runPush(cmd *cobra.Command, args []string) {
 		logger,
 	)
 	if err != nil {
-		utils.Errorln("[ERROR]", err)
+		reportCommandError(err)
 		os.Exit(1)
 	}
 

--- a/app/src/core/core.go
+++ b/app/src/core/core.go
@@ -72,7 +72,7 @@ type EnvData struct {
 // キーはファイル名（例: ".env", ".env.staging"）
 type MultiEnvData map[string]EnvData
 
-// IsLockedError はエラーがロック関連かどうかを判定します。
+// IsLockedError はエラーがロック関連（CLI）かどうかを判定します。
 func IsLockedError(err error) bool {
 	if err == nil {
 		return false
@@ -83,7 +83,32 @@ func IsLockedError(err error) bool {
 		strings.Contains(errMsg, "master password")
 }
 
-// WithUnlockRetry は Bitwarden がロックされている場合に Unlock/Login を挟んでリトライする共通処理です。
+// IsNotAuthenticatedError は API 未認証（bwsf auth が必要）かを判定します。
+func IsNotAuthenticatedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if strings.Contains(err.Error(), "API backend is not authenticated") {
+		return true
+	}
+	return false
+}
+
+// IsNotUnlockedError は復号鍵が無い／unlock が必要かを判定します。
+func IsNotUnlockedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if IsLockedError(err) {
+		return true
+	}
+	errMsg := err.Error()
+	return strings.Contains(errMsg, "API vault is locked") ||
+		strings.Contains(errMsg, "Enter your master password to unlock")
+}
+
+// WithUnlockRetry は未 unlock / CLI ロック時に Unlock（必要なら Login）を挟んでリトライします。
+// 認証切れはパスワードでは回復できないため、プロンプトせずそのまま返します。
 func WithUnlockRetry(
 	bw BwClient,
 	cfg *config.Config,
@@ -91,55 +116,54 @@ func WithUnlockRetry(
 	logger Logger,
 	fn func() error,
 ) error {
-	// 最初に fn() を実行
 	err := fn()
 	if err == nil {
 		return nil
 	}
 
-	// ロック関連エラーでなければそのまま返す
-	if !IsLockedError(err) {
+	if IsNotAuthenticatedError(err) {
 		return err
 	}
 
-	// ロック状態なのでアンロックを試みる
-	logger.Info("Bitwarden CLI is locked. Please enter your master password to unlock.")
+	if !IsNotUnlockedError(err) {
+		return err
+	}
 
-	// パスワード入力
+	logger.Info("Vault is locked. Please enter your master password to unlock.")
+
 	password, promptErr := promptPassword()
 	if promptErr != nil {
 		return fmt.Errorf("failed to get master password: %w", promptErr)
 	}
 
-	// Unlock を試行
 	unlockErr := bw.Unlock(password)
 	if unlockErr == nil {
-		// Unlock 成功、fn() を再実行
-		logger.Info("Bitwarden CLI unlocked successfully")
+		logger.Info("Vault unlocked successfully")
 		return fn()
 	}
 
-	// Unlock 失敗、cfg があれば Login を試みる
+	// bw 経路互換: Unlock 失敗後に Login → Unlock
 	if cfg != nil && cfg.Email != "" {
 		logger.Info("Unlock failed, trying login then unlock...")
 		loginErr := bw.Login(cfg.Email, password, cfg.SelfhostedURL)
 		if loginErr != nil {
+			// api Login は API Key 認証なので、ここでの失敗は認証切れとして返す
+			if IsNotAuthenticatedError(loginErr) {
+				return loginErr
+			}
 			return fmt.Errorf("failed to login Bitwarden CLI: %w", loginErr)
 		}
 		logger.Info("Bitwarden CLI logged in successfully")
 
-		// Login 成功後、再度 Unlock を試行
 		unlockErr = bw.Unlock(password)
 		if unlockErr != nil {
-			return fmt.Errorf("failed to unlock Bitwarden CLI after login: %w", unlockErr)
+			return fmt.Errorf("failed to unlock after login: %w", unlockErr)
 		}
-		logger.Info("Bitwarden CLI unlocked successfully")
-
-		// fn() を再実行
+		logger.Info("Vault unlocked successfully")
 		return fn()
 	}
 
-	return fmt.Errorf("failed to unlock Bitwarden CLI: %w", unlockErr)
+	return fmt.Errorf("failed to unlock vault: %w", unlockErr)
 }
 
 // PushEnvCore は .env ファイルを Bitwarden にプッシュするコアロジックです。

--- a/app/src/core/core_test.go
+++ b/app/src/core/core_test.go
@@ -359,6 +359,58 @@ func TestWithUnlockRetry_NonLockErrorPropagates(t *testing.T) {
 	assert.NotContains(t, bw.calls, "Login")
 }
 
+// 異常系: 認証切れは MP プロンプトせずそのまま返す
+func TestWithUnlockRetry_NotAuthenticatedNoPrompt(t *testing.T) {
+	bw := &mockBwClient{}
+	logger := &mockLogger{}
+	cfg := &config.Config{}
+	promptCalled := false
+
+	authErr := errors.New("API backend is not authenticated. Run `bwsf auth`")
+	err := WithUnlockRetry(
+		bw,
+		cfg,
+		func() (string, error) {
+			promptCalled = true
+			return "pwd", nil
+		},
+		logger,
+		func() error { return authErr },
+	)
+
+	assert.Error(t, err)
+	assert.Equal(t, authErr, err)
+	assert.False(t, promptCalled)
+	assert.True(t, IsNotAuthenticatedError(authErr))
+}
+
+// 正常系: API vault locked 文言で Unlock 再試行する
+func TestWithUnlockRetry_APINotUnlockedThenSuccess(t *testing.T) {
+	bw := &mockBwClient{}
+	logger := &mockLogger{}
+	cfg := &config.Config{Email: "a@example.com"}
+	callCount := 0
+
+	err := WithUnlockRetry(
+		bw,
+		cfg,
+		func() (string, error) { return "pwd", nil },
+		logger,
+		func() error {
+			callCount++
+			if callCount == 1 {
+				return errors.New("API vault is locked. Enter your master password to unlock decryption keys")
+			}
+			return nil
+		},
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+	assert.Contains(t, bw.calls, "Unlock")
+	assert.True(t, IsNotUnlockedError(errors.New("API vault is locked. Enter your master password to unlock decryption keys")))
+}
+
 // 異常系: promptPassword がエラーを返した場合、Unlock/Login が呼ばれずにそのエラーが返る
 func TestWithUnlockRetry_PromptPasswordError(t *testing.T) {
 	bw := &mockBwClient{}

--- a/app/src/infra/apiclient.go
+++ b/app/src/infra/apiclient.go
@@ -25,17 +25,24 @@ var ErrAPINotAuthenticated = errors.New(
 	"API backend is not authenticated. Run `bwsf auth` to store your Personal API Key and obtain a token",
 )
 
-// ErrAPIUnlockNotImplemented is returned until Issue #53 Step 3 (master password → crypto keys).
+// ErrAPINotUnlocked means Identity auth succeeded but vault decryption keys are missing.
+var ErrAPINotUnlocked = errors.New(
+	"API vault is locked. Enter your master password to unlock decryption keys",
+)
+
+// ErrAPIUnlockNotImplemented is kept for older call sites; Unlock is implemented in Step 3.
 var ErrAPIUnlockNotImplemented = errors.New(
 	"API vault unlock (master password / crypto keys) is not implemented yet (Issue #53 Step 3)",
 )
 
 // ApiBwClient is the Bitwarden API backend adapter.
-// Step 2: Personal API Key + Identity token. Vault CRUD remains stubbed.
+// Step 3: Personal API Key + Identity token + master-password unlock (SDK).
+// Vault CRUD remains stubbed until Step 4.
 type ApiBwClient struct {
 	cfg      *config.Config
 	store    SecretStore
 	identity *IdentityClient
+	crypto   CryptoSession
 
 	mu    sync.Mutex
 	token *TokenSet
@@ -43,11 +50,11 @@ type ApiBwClient struct {
 
 // NewApiBwClient creates an ApiBwClient with OS keyring and default HTTP client.
 func NewApiBwClient(cfg *config.Config) *ApiBwClient {
-	return NewApiBwClientWithDeps(cfg, NewKeyringStore(), NewIdentityClient())
+	return NewApiBwClientWithDeps(cfg, NewKeyringStore(), NewIdentityClient(), NewSDKCryptoSession())
 }
 
 // NewApiBwClientWithDeps creates an ApiBwClient with injectable dependencies (tests).
-func NewApiBwClientWithDeps(cfg *config.Config, store SecretStore, identity *IdentityClient) *ApiBwClient {
+func NewApiBwClientWithDeps(cfg *config.Config, store SecretStore, identity *IdentityClient, crypto CryptoSession) *ApiBwClient {
 	if cfg == nil {
 		cfg = &config.Config{}
 	}
@@ -57,10 +64,14 @@ func NewApiBwClientWithDeps(cfg *config.Config, store SecretStore, identity *Ide
 	if identity == nil {
 		identity = NewIdentityClient()
 	}
+	if crypto == nil {
+		crypto = NewSDKCryptoSession()
+	}
 	return &ApiBwClient{
 		cfg:      cfg,
 		store:    store,
 		identity: identity,
+		crypto:   crypto,
 	}
 }
 
@@ -139,7 +150,6 @@ func (c *ApiBwClient) EnsureAccessToken(ctx context.Context) (string, error) {
 		return token.AccessToken, nil
 	}
 
-	// Prefer refresh_token when present (client_credentials often has none).
 	if token != nil && token.RefreshToken != "" {
 		identityBase, err := ResolveIdentityBase(c.cfg.HostType, c.cfg.SelfhostedURL)
 		if err != nil {
@@ -180,11 +190,22 @@ func (c *ApiBwClient) IsAuthenticated() bool {
 	return c.token.Valid()
 }
 
-// ClearSession drops the in-memory token (does not remove Keychain secrets).
+// IsUnlocked reports whether vault decryption keys are present in memory.
+func (c *ApiBwClient) IsUnlocked() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.crypto != nil && c.crypto.Unlocked()
+}
+
+// ClearSession drops the in-memory token and decryption keys (does not remove Keychain secrets).
 func (c *ApiBwClient) ClearSession() {
 	c.mu.Lock()
 	c.token = nil
+	crypto := c.crypto
 	c.mu.Unlock()
+	if crypto != nil {
+		crypto.Lock()
+	}
 }
 
 // TokenExpiresAt exposes token expiry for diagnostics/tests.
@@ -197,35 +218,71 @@ func (c *ApiBwClient) TokenExpiresAt() time.Time {
 	return c.token.ExpiresAt
 }
 
+func (c *ApiBwClient) requireUnlocked() error {
+	if !c.IsAuthenticated() {
+		if err := c.Authenticate(context.Background()); err != nil {
+			return err
+		}
+	}
+	if !c.IsUnlocked() {
+		return ErrAPINotUnlocked
+	}
+	return nil
+}
+
 func (c *ApiBwClient) GetDotenvsFolderID() (string, error) {
+	if err := c.requireUnlocked(); err != nil {
+		return "", err
+	}
 	return "", ErrAPINotImplemented
 }
 
 func (c *ApiBwClient) DotenvsFolderExists() (bool, error) {
+	if err := c.requireUnlocked(); err != nil {
+		return false, err
+	}
 	return false, ErrAPINotImplemented
 }
 
 func (c *ApiBwClient) CreateDotenvsFolder() error {
+	if err := c.requireUnlocked(); err != nil {
+		return err
+	}
 	return ErrAPINotImplemented
 }
 
 func (c *ApiBwClient) ListItemsInFolder(folderID string) ([]core.Item, error) {
+	if err := c.requireUnlocked(); err != nil {
+		return nil, err
+	}
 	return nil, ErrAPINotImplemented
 }
 
 func (c *ApiBwClient) GetItemByName(folderID, name string) (*core.FullItem, error) {
+	if err := c.requireUnlocked(); err != nil {
+		return nil, err
+	}
 	return nil, ErrAPINotImplemented
 }
 
 func (c *ApiBwClient) GetItemByID(id string) (*core.FullItem, error) {
+	if err := c.requireUnlocked(); err != nil {
+		return nil, err
+	}
 	return nil, ErrAPINotImplemented
 }
 
 func (c *ApiBwClient) CreateNoteItem(folderID, name, notes string) error {
+	if err := c.requireUnlocked(); err != nil {
+		return err
+	}
 	return ErrAPINotImplemented
 }
 
 func (c *ApiBwClient) UpdateNoteItem(id, notes string) error {
+	if err := c.requireUnlocked(); err != nil {
+		return err
+	}
 	return ErrAPINotImplemented
 }
 
@@ -243,13 +300,45 @@ func (c *ApiBwClient) Login(email, password, serverURL string) error {
 	return c.Authenticate(context.Background())
 }
 
-// Unlock is not available until Step 3 (master password → decryption keys).
+// Unlock restores vault decryption keys with the master password.
+// Caveat (pending Scenario C): keys are obtained via SDK password login using
+// config email + MP. Identity Personal API Key tokens remain separate.
 func (c *ApiBwClient) Unlock(masterPassword string) error {
-	_ = masterPassword
+	if masterPassword == "" {
+		return fmt.Errorf("master password cannot be empty")
+	}
 	if !c.IsAuthenticated() {
 		if err := c.Authenticate(context.Background()); err != nil {
 			return err
 		}
 	}
-	return ErrAPIUnlockNotImplemented
+	if c.cfg.Email == "" {
+		return fmt.Errorf("email is required in config for API vault unlock (run bwsf setup)")
+	}
+
+	deviceID, err := EnsureDeviceIdentifier(c.cfg)
+	if err != nil {
+		return err
+	}
+	device := DefaultDeviceInfo(deviceID)
+
+	serverURL := ""
+	if c.cfg.HostType == "selfhosted" {
+		serverURL = c.cfg.SelfhostedURL
+	}
+
+	c.mu.Lock()
+	crypto := c.crypto
+	c.mu.Unlock()
+	if crypto == nil {
+		crypto = NewSDKCryptoSession()
+		c.mu.Lock()
+		c.crypto = crypto
+		c.mu.Unlock()
+	}
+
+	if err := crypto.UnlockWithPassword(context.Background(), c.cfg.Email, masterPassword, serverURL, device); err != nil {
+		return err
+	}
+	return nil
 }

--- a/app/src/infra/auth_test.go
+++ b/app/src/infra/auth_test.go
@@ -188,7 +188,7 @@ func TestApiBwClient_AuthenticateAndLogin(t *testing.T) {
 	}
 
 	cfg := &config.Config{HostType: "cloud", Backend: config.BackendAPI}
-	client := NewApiBwClientWithDeps(cfg, store, identity)
+	client := NewApiBwClientWithDeps(cfg, store, identity, nil)
 
 	require.NoError(t, client.Authenticate(context.Background()))
 	assert.True(t, client.IsAuthenticated())
@@ -201,16 +201,10 @@ func TestApiBwClient_AuthenticateAndLogin(t *testing.T) {
 	assert.False(t, client.IsAuthenticated())
 	require.NoError(t, client.Login("ignored@example.com", "ignored", ""))
 	assert.True(t, client.IsAuthenticated())
-
-	err = client.Unlock("master")
-	assert.ErrorIs(t, err, ErrAPIUnlockNotImplemented)
-
-	_, err = client.GetDotenvsFolderID()
-	assert.ErrorIs(t, err, ErrAPINotImplemented)
 }
 
 func TestApiBwClient_Authenticate_MissingCredentials(t *testing.T) {
-	client := NewApiBwClientWithDeps(&config.Config{HostType: "cloud"}, NewMemorySecretStore(), NewIdentityClient())
+	client := NewApiBwClientWithDeps(&config.Config{HostType: "cloud"}, NewMemorySecretStore(), NewIdentityClient(), nil)
 	err := client.Authenticate(context.Background())
 	assert.ErrorIs(t, err, ErrAPINotAuthenticated)
 }
@@ -240,7 +234,7 @@ func TestApiBwClient_EnsureAccessToken_Refresh(t *testing.T) {
 
 	store := NewMemorySecretStore()
 	_ = SaveAPICredentials(store, APICredentials{ClientID: "user.cid", ClientSecret: "sec"})
-	client := NewApiBwClientWithDeps(&config.Config{HostType: "cloud"}, store, identity)
+	client := NewApiBwClientWithDeps(&config.Config{HostType: "cloud"}, store, identity, nil)
 	client.mu.Lock()
 	client.token = &TokenSet{
 		AccessToken:  "old",

--- a/app/src/infra/crypto_session.go
+++ b/app/src/infra/crypto_session.go
@@ -1,0 +1,101 @@
+package infra
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bnema/bitwarden-go-sdk/bitwarden"
+)
+
+// CryptoSession restores and holds vault decryption keys in process memory.
+// Implemented with the Community SDK (password login) until Scenario C confirms
+// Personal API Key token injection + MP-only unlock.
+type CryptoSession interface {
+	UnlockWithPassword(ctx context.Context, email, password, serverURL string, device DeviceInfo) error
+	Lock()
+	Unlocked() bool
+}
+
+// SDKCryptoSession wraps bitwarden-go-sdk Client for unlock/lock.
+type SDKCryptoSession struct {
+	client *bitwarden.Client
+}
+
+// NewSDKCryptoSession returns a locked crypto session.
+func NewSDKCryptoSession() *SDKCryptoSession {
+	return &SDKCryptoSession{}
+}
+
+// UnlockWithPassword performs SDK BeginLogin to restore user keys.
+func (s *SDKCryptoSession) UnlockWithPassword(ctx context.Context, email, password, serverURL string, device DeviceInfo) error {
+	if email == "" {
+		return fmt.Errorf("email is required in config for API vault unlock (run bwsf setup)")
+	}
+	if password == "" {
+		return fmt.Errorf("master password cannot be empty")
+	}
+
+	var opts []bitwarden.Option
+	if serverURL != "" {
+		opts = append(opts, bitwarden.WithServerURL(serverURL))
+	}
+
+	client, err := bitwarden.NewClient(opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create vault SDK client: %w", err)
+	}
+
+	result, err := client.BeginLogin(ctx, bitwarden.LoginOptions{
+		Email:            email,
+		Password:         password,
+		DeviceType:       sdkDeviceTypeName(device.Type),
+		DeviceIdentifier: device.Identifier,
+		DeviceName:       device.Name,
+	})
+	if err != nil {
+		_ = client.Logout(ctx)
+		return fmt.Errorf("failed to unlock vault with master password: %w", err)
+	}
+	if result.Challenge != nil {
+		result.Challenge.Close()
+		_ = client.Logout(ctx)
+		return fmt.Errorf("two-factor authentication is required but not supported yet for API unlock")
+	}
+
+	if s.client != nil {
+		_ = s.client.Logout(context.Background())
+	}
+	s.client = client
+	return nil
+}
+
+// Lock discards in-memory SDK keys/tokens.
+func (s *SDKCryptoSession) Lock() {
+	if s == nil || s.client == nil {
+		return
+	}
+	s.client.Lock()
+	_ = s.client.Logout(context.Background())
+	s.client = nil
+}
+
+// Unlocked reports whether the SDK client holds decryption keys.
+func (s *SDKCryptoSession) Unlocked() bool {
+	return s != nil && s.client != nil && !s.client.IsLocked()
+}
+
+func sdkDeviceTypeName(numericOrName string) string {
+	switch numericOrName {
+	case "6", "WindowsDesktop":
+		return "WindowsDesktop"
+	case "7", "MacOsDesktop":
+		return "MacOsDesktop"
+	case "8", "LinuxDesktop":
+		return "LinuxDesktop"
+	default:
+		if numericOrName != "" {
+			return numericOrName
+		}
+		return "LinuxDesktop"
+	}
+}

--- a/app/src/infra/crypto_session_mock.go
+++ b/app/src/infra/crypto_session_mock.go
@@ -1,0 +1,33 @@
+package infra
+
+import "context"
+
+// MockCryptoSession is a test double for CryptoSession.
+type MockCryptoSession struct {
+	UnlockErr error
+	unlocked  bool
+	Calls     []string
+}
+
+func (m *MockCryptoSession) UnlockWithPassword(ctx context.Context, email, password, serverURL string, device DeviceInfo) error {
+	m.Calls = append(m.Calls, "UnlockWithPassword")
+	_ = ctx
+	_ = email
+	_ = password
+	_ = serverURL
+	_ = device
+	if m.UnlockErr != nil {
+		return m.UnlockErr
+	}
+	m.unlocked = true
+	return nil
+}
+
+func (m *MockCryptoSession) Lock() {
+	m.Calls = append(m.Calls, "Lock")
+	m.unlocked = false
+}
+
+func (m *MockCryptoSession) Unlocked() bool {
+	return m.unlocked
+}

--- a/app/src/infra/infra_test.go
+++ b/app/src/infra/infra_test.go
@@ -131,39 +131,23 @@ func TestNewBwClientFromConfig_Unsupported(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported backend")
 }
 
-// 正常系: ApiBwClient の保管庫メソッドは not implemented、Unlock は Step 3 案内
-func TestApiBwClient_NotImplemented(t *testing.T) {
+// 異常系: 未認証では保管庫メソッドが auth エラーになる
+func TestApiBwClient_VaultRequiresAuth(t *testing.T) {
 	client := NewApiBwClientWithDeps(
 		&config.Config{Backend: config.BackendAPI},
 		NewMemorySecretStore(),
 		NewIdentityClient(),
+		nil,
 	)
 
 	_, err := client.GetDotenvsFolderID()
-	assert.ErrorIs(t, err, ErrAPINotImplemented)
-
-	_, err = client.DotenvsFolderExists()
-	assert.ErrorIs(t, err, ErrAPINotImplemented)
-
-	assert.ErrorIs(t, client.CreateDotenvsFolder(), ErrAPINotImplemented)
+	assert.ErrorIs(t, err, ErrAPINotAuthenticated)
 
 	_, err = client.ListItemsInFolder("id")
-	assert.ErrorIs(t, err, ErrAPINotImplemented)
+	assert.ErrorIs(t, err, ErrAPINotAuthenticated)
 
-	_, err = client.GetItemByName("id", "name")
-	assert.ErrorIs(t, err, ErrAPINotImplemented)
-
-	_, err = client.GetItemByID("id")
-	assert.ErrorIs(t, err, ErrAPINotImplemented)
-
-	assert.ErrorIs(t, client.CreateNoteItem("id", "n", "notes"), ErrAPINotImplemented)
-	assert.ErrorIs(t, client.UpdateNoteItem("id", "notes"), ErrAPINotImplemented)
-
-	// Login without stored API key asks for bwsf auth
 	assert.ErrorIs(t, client.Login("e", "p", ""), ErrAPINotAuthenticated)
-
 	assert.Contains(t, ErrAPINotImplemented.Error(), "Issue #53")
-	assert.Contains(t, ErrAPINotImplemented.Error(), "bwsf backend --set bw")
 }
 
 // 正常系: ApiBwClient が BwClient インターフェースを実装している

--- a/app/src/infra/unlock_test.go
+++ b/app/src/infra/unlock_test.go
@@ -1,0 +1,125 @@
+package infra
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"bwsf/src/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApiBwClient_Unlock_SuccessAndClearSession(t *testing.T) {
+	withTempHome(t)
+
+	store := NewMemorySecretStore()
+	_ = SaveAPICredentials(store, APICredentials{ClientID: "user.cid", ClientSecret: "sec"})
+	identity := &IdentityClient{
+		HTTPClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				payload := `{"access_token":"tok","expires_in":3600}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(payload)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+	crypto := &MockCryptoSession{}
+	client := NewApiBwClientWithDeps(
+		&config.Config{HostType: "cloud", Email: "a@example.com", Backend: config.BackendAPI},
+		store,
+		identity,
+		crypto,
+	)
+
+	require.NoError(t, client.Authenticate(context.Background()))
+	_, err := client.ListItemsInFolder("f")
+	assert.ErrorIs(t, err, ErrAPINotUnlocked)
+
+	require.NoError(t, client.Unlock("master-pass"))
+	assert.True(t, client.IsUnlocked())
+	assert.Contains(t, crypto.Calls, "UnlockWithPassword")
+
+	_, err = client.ListItemsInFolder("f")
+	assert.ErrorIs(t, err, ErrAPINotImplemented)
+
+	client.ClearSession()
+	assert.False(t, client.IsAuthenticated())
+	assert.False(t, client.IsUnlocked())
+	assert.Contains(t, crypto.Calls, "Lock")
+
+	_ = SaveAPICredentials(store, APICredentials{ClientID: "user.cid", ClientSecret: "sec"})
+	require.NoError(t, client.Authenticate(context.Background()))
+	assert.True(t, client.IsAuthenticated())
+}
+
+func TestApiBwClient_Unlock_EmptyPassword(t *testing.T) {
+	client := NewApiBwClientWithDeps(
+		&config.Config{HostType: "cloud", Email: "a@example.com"},
+		NewMemorySecretStore(),
+		NewIdentityClient(),
+		&MockCryptoSession{},
+	)
+	err := client.Unlock("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be empty")
+}
+
+func TestApiBwClient_Unlock_MissingEmail(t *testing.T) {
+	withTempHome(t)
+	store := NewMemorySecretStore()
+	_ = SaveAPICredentials(store, APICredentials{ClientID: "user.cid", ClientSecret: "sec"})
+	identity := &IdentityClient{
+		HTTPClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				payload := `{"access_token":"tok","expires_in":3600}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(payload)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+	client := NewApiBwClientWithDeps(&config.Config{HostType: "cloud"}, store, identity, &MockCryptoSession{})
+	require.NoError(t, client.Authenticate(context.Background()))
+	err := client.Unlock("mp")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "email is required")
+}
+
+func TestApiBwClient_Unlock_CryptoFailure(t *testing.T) {
+	withTempHome(t)
+	store := NewMemorySecretStore()
+	_ = SaveAPICredentials(store, APICredentials{ClientID: "user.cid", ClientSecret: "sec"})
+	identity := &IdentityClient{
+		HTTPClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				payload := `{"access_token":"tok","expires_in":3600}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(payload)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+	crypto := &MockCryptoSession{UnlockErr: fmt.Errorf("bad password")}
+	client := NewApiBwClientWithDeps(
+		&config.Config{HostType: "cloud", Email: "a@example.com"},
+		store,
+		identity,
+		crypto,
+	)
+	require.NoError(t, client.Authenticate(context.Background()))
+	err := client.Unlock("wrong")
+	assert.Error(t, err)
+	assert.False(t, client.IsUnlocked())
+}


### PR DESCRIPTION
## Summary
Issue #53 **Step 3** (PR-C): implement API backend vault unlock and key lifetime.

- Add Community SDK (`bitwarden-go-sdk`) behind `CryptoSession`
- `ApiBwClient.Unlock(mp)` restores decryption keys; `ClearSession` drops token + keys
- `WithUnlockRetry` separates **auth required** (`bwsf auth`) vs **unlock required** (MP prompt)
- `list` / `push` / `pull` defer session clear on exit
- Vault CRUD still returns `ErrAPINotImplemented` (Step 4)

### Depends on
- Ideally merge [#105](https://github.com/b4moss/bwsf/pull/105) (Go 1.26) first — this branch is based on it and includes those commits until then.

### Caveat (Scenario C)
Unlock currently uses SDK **password login** (config email + master password) for key material. Identity Personal API Key tokens remain separate. Documented in README.

### Test plan
- [x] `go test ./...` (GOTOOLCHAIN=auto / Go 1.26)
- [ ] Manual VW: `backend=api` → `auth` → `list` prompts MP then hits Step 4 stub

Related: #53