### PR TITLE
fix: make SaveConfig error test pass as root (Codespaces)

### DIFF
--- a/app/src/config/config.go
+++ b/app/src/config/config.go
@@ -81,7 +81,7 @@ func SaveConfig(config *Config) error {
 
 	// Create config directory if it doesn't exist
 	configDirPath := filepath.Dir(configPath)
-	if err := os.MkdirAll(configDirPath, 0755); err != nil {
+	if err := mkdirAll(configDirPath, 0755); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
@@ -90,9 +90,33 @@ func SaveConfig(config *Config) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	if err := os.WriteFile(configPath, data, 0600); err != nil {
+	if err := writeFile(configPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
 	return nil
+}
+
+// OS helpers used by SaveConfig (overridable in tests; root ignores chmod tricks).
+var (
+	mkdirAll  = os.MkdirAll
+	writeFile = os.WriteFile
+)
+
+// OverrideSaveConfigIO swaps SaveConfig filesystem helpers for tests. Call the
+// returned function to restore the previous implementations.
+func OverrideSaveConfigIO(
+	mkdirAllFn func(string, os.FileMode) error,
+	writeFileFn func(string, []byte, os.FileMode) error,
+) func() {
+	prevMkdir, prevWrite := mkdirAll, writeFile
+	if mkdirAllFn != nil {
+		mkdirAll = mkdirAllFn
+	}
+	if writeFileFn != nil {
+		writeFile = writeFileFn
+	}
+	return func() {
+		mkdirAll, writeFile = prevMkdir, prevWrite
+	}
 }

--- a/app/src/core/core_test.go
+++ b/app/src/core/core_test.go
@@ -2294,12 +2294,12 @@ func TestSetupAPIConfigCore_EmptySelfhostedURL(t *testing.T) {
 
 // 異常系: 設定保存に失敗した場合はエラー（Login 経路は存在しない）
 func TestSetupAPIConfigCore_SaveConfigError(t *testing.T) {
-	home := withTempHome(t)
-	configDir := filepath.Join(home, ".config", "bwsf")
-	assert.NoError(t, os.MkdirAll(configDir, 0755))
-	// No config file yet (LoadConfig → nil). Directory is read-only so create fails.
-	assert.NoError(t, os.Chmod(configDir, 0500))
-	t.Cleanup(func() { _ = os.Chmod(configDir, 0755) })
+	withTempHome(t)
+	// chmod-based read-only dirs are ignored when running as root (Docker / Codespaces).
+	restore := config.OverrideSaveConfigIO(nil, func(string, []byte, os.FileMode) error {
+		return errors.New("disk full")
+	})
+	t.Cleanup(restore)
 	logger := &mockLogger{}
 
 	err := SetupAPIConfigCore(


### PR DESCRIPTION
## Summary
- `make test` failed on Codespaces/Docker after merging Step 3 because `TestSetupAPIConfigCore_SaveConfigError` used `chmod 0500`, which root ignores.
- Add a SaveConfig IO test seam and force a write error so the case works as root.

## Test plan
- [x] `make test` (Docker, root) passes locally
- [x] `go test ./src/config/ ./src/core/` passes as non-root