### PR TITLE
feat: Dev Container / Codespaces environment (#111)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,42 @@
+# Dev Container / Codespaces
+
+Issue: [#111](https://github.com/b4moss/bwsf/issues/111)  
+Depends on smoke foundation: [#109](https://github.com/b4moss/bwsf/issues/109), [#110](https://github.com/b4moss/bwsf/issues/110)
+
+## What is included
+
+| Tool | Notes |
+|------|--------|
+| Go 1.25 | Matches `app/go.mod` on the v0.13 line |
+| Node.js + `bw` | `@bitwarden/cli` via `post-create.sh` |
+| Docker + Compose | **Docker-outside-of-Docker** (host/Codespaces engine via socket) |
+| Make | Used for `make test` / `make smoke*` |
+
+Vaultwarden is **not** started at container create time. Use the existing Compose `smoke` profile when needed (`make smoke-up`).
+
+## Open in Codespaces / VS Code
+
+1. Open the repo in GitHub Codespaces, or VS Code → “Reopen in Container”
+2. Wait for `post-create.sh` (installs `bw`, downloads Go modules)
+3. Run:
+
+```bash
+make test
+```
+
+Optional real-server smoke:
+
+```bash
+make smoke-up
+make smoke-ready
+make smoke
+```
+
+See [`docs/smoke.md`](../docs/smoke.md).
+
+## Acceptance (v0.13.0)
+
+- Codespaces / Dev Container starts
+- `go`, `bw`, and `docker compose` are available
+- `make test` passes (required)
+- `make smoke` passes once manually (recommended)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "bwsf",
+  "image": "mcr.microsoft.com/devcontainers/go:1.25-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22",
+      "installYarn": false
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "latest",
+      "moby": true,
+      "dockerDashComposeVersion": "v2"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "go.useLanguageServer": true,
+        "go.toolsManagement.checkForUpdates": "local"
+      },
+      "extensions": ["golang.Go"]
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Minimal bootstrap for Codespaces / Dev Containers (#111).
+set -euo pipefail
+
+echo "[devcontainer] Installing Bitwarden CLI (bw)..."
+npm install -g @bitwarden/cli
+
+echo "[devcontainer] Ensuring make is available..."
+if ! command -v make >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y --no-install-recommends make
+fi
+
+echo "[devcontainer] Downloading Go modules..."
+(cd app && go mod download)
+
+echo "[devcontainer] Versions:"
+go version
+node --version
+npm --version
+bw --version || true
+docker version --format 'docker {{.Server.Version}}' 2>/dev/null || docker version || true
+docker compose version || true
+
+echo "[devcontainer] Ready. Try: make test"
+echo "[devcontainer] Optional smoke: make smoke-up && make smoke-ready && make smoke"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,20 @@ Before you begin, ensure you have the following installed:
 
 ### Development Setup
 
+#### Option A: GitHub Codespaces / Dev Container (recommended)
+
+1. Open the repository in **Codespaces**, or VS Code → “Reopen in Container”
+2. Wait for `.devcontainer/post-create.sh` (installs `bw`, downloads Go modules)
+3. Run server-free tests:
+
+```bash
+make test
+```
+
+Details: [`.devcontainer/README.md`](./.devcontainer/README.md). Vaultwarden smoke remains on-demand (`make smoke*`); see [`docs/smoke.md`](./docs/smoke.md).
+
+#### Option B: Local Docker Compose
+
 1. Fork the repository on GitHub
 2. Clone your fork:
 

--- a/docs/smoke.md
+++ b/docs/smoke.md
@@ -4,6 +4,7 @@ Development / CI helpers for **real-server** checks against Vaultwarden.
 
 - Issue: [#109](https://github.com/b4moss/bwsf/issues/109) (foundation), [#110](https://github.com/b4moss/bwsf/issues/110) (`make smoke` commands)
 - Parent tracker: [#108](https://github.com/b4moss/bwsf/issues/108)
+- Dev Container / Codespaces: [`.devcontainer/README.md`](../.devcontainer/README.md) ([#111](https://github.com/b4moss/bwsf/issues/111))
 
 ## Test target split
 


### PR DESCRIPTION
## Summary
- Closes #111
- `.devcontainer`: Go 1.25, Node 22, **Docker-outside-of-Docker**, Compose v2
- `post-create.sh` installs `bw` and downloads Go modules
- Vaultwarden stays on-demand via existing `make smoke*` (#109/#110)
- Docs: `.devcontainer/README.md`, CONTRIBUTING, smoke guide link

Stacked on #117 (`cursor/v0.13.0-dev-enhance-78df`). After #117 merges to `dev-v0.13.0`, retarget this PR if needed.

## Test plan
- [x] `make test` (Docker) on this branch
- [ ] Open in Codespaces / Reopen in Container and confirm `go` / `bw` / `docker compose`
- [ ] `make test` inside the Dev Container
- [ ] (Recommended) `make smoke` once