### PR TITLE
docs: update README version examples to 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This project migrates our hand-maded shell scripts to modern CLI command with Go
 
 ```shell
 bwsf -v
-# bwsf version 0.11.2
+# bwsf version 0.14.0
 ```
 
 ## Usage

--- a/README_ja.md
+++ b/README_ja.md
@@ -82,7 +82,7 @@ bwsfコマンドは、Bitwardenで管理されているdotenvファイルをサ�
 
 ```shell
 bwsf -v
-# bwsf version 0.11.2
+# bwsf version 0.14.0
 ```
 
 ## 使い方


### PR DESCRIPTION
## Summary
- Update install verification sample output in README EN/JA from `0.11.2` to `0.14.0`

## Test plan
- [x] Grep confirms no remaining `0.11.2` examples in READMEs