### PR TITLE
docs: show latest app version beside header brand

### DIFF
--- a/docs/site/.env.example
+++ b/docs/site/.env.example
@@ -5,6 +5,7 @@ NUXT_PUBLIC_SCRIPTS_GOOGLE_TAG_MANAGER_ID=
 
 # Optional site branding overrides (also editable in nuxt.config.ts)
 # NUXT_PUBLIC_SITE_NAME=bwsf
-# NUXT_PUBLIC_SITE_VERSION=0.1.0
+# Default siteVersion is read from app/src/cmd/version.go (e.g. v0.15.0).
+# NUXT_PUBLIC_SITE_VERSION=v0.15.0
 # NUXT_PUBLIC_GITHUB_URL=https://github.com/b4moss/bwsf
 # NUXT_PUBLIC_FOOTER_TEXT=MIT License · 2026 Bicycle for Mind LLC.

--- a/docs/site/nuxt.config.ts
+++ b/docs/site/nuxt.config.ts
@@ -1,5 +1,20 @@
-import { copyFileSync } from "node:fs";
+import { copyFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Latest product version from app/src/cmd/version.go (single source of truth). */
+function readAppVersion(): string {
+  const repoRoot = join(fileURLToPath(new URL(".", import.meta.url)), "../..");
+  const versionGo = readFileSync(
+    join(repoRoot, "app/src/cmd/version.go"),
+    "utf8",
+  );
+  const match = versionGo.match(/const Version = "([^"]+)"/);
+  if (!match) {
+    throw new Error("Could not parse Version from app/src/cmd/version.go");
+  }
+  return `v${match[1]}`;
+}
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
@@ -15,7 +30,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       siteName: "bwsf",
-      siteVersion: "",
+      siteVersion: readAppVersion(),
       githubUrl: "https://github.com/b4moss/bwsf",
       footerText: "MIT License · 2026 Bicycle for Mind LLC.",
     },


### PR DESCRIPTION
## Summary
- ヘッダー左上のブランド名右に、最新アプリバージョン（例: `v0.15.0`）を表示
- 値は `app/src/cmd/version.go` の `Version` からビルド時に読み取り（単一ソース）

## Test plan
- [x] `cd docs/site && npm run generate` 成功
- [x] 出力 HTML に `siteVersion:"v0.15.0"` / ヘッダー `.versions` があること
- [ ] マージ後に docs タグを打って Pages 反映を確認